### PR TITLE
Euclid length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/logging.h> $<INSTALL_INTERFACE:include/floppy/logging.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/angle.h> $<INSTALL_INTERFACE:include/floppy/euclid/angle.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/scale.h> $<INSTALL_INTERFACE:include/floppy/euclid/scale.h>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/length.h> $<INSTALL_INTERFACE:include/floppy/euclid/length.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/inl/configuration.inl> $<INSTALL_INTERFACE:include/floppy/inl/configuration.inl>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/detail/export.h> $<INSTALL_INTERFACE:include/floppy/detail/export.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/detail/predefs.h> $<INSTALL_INTERFACE:include/floppy/detail/predefs.h>

--- a/include/floppy/detail/export.h
+++ b/include/floppy/detail/export.h
@@ -132,7 +132,7 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
     [[maybe_unused]] constexpr inline auto floppy_meta = project_meta(
       version(CMAKE_PROJECT_VERSION_MAJOR, CMAKE_PROJECT_VERSION_MINOR, CMAKE_PROJECT_VERSION_PATCH),
       std::string_view(stringify$(CMAKE_TARGET_NAME)),
-      "io",
+      "io.github.whs31",
       "whs31"
     );
 
@@ -140,7 +140,7 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
     static_assert(floppy_meta.version().minor() == CMAKE_PROJECT_VERSION_MINOR, "minor version isn't the same");
     static_assert(floppy_meta.version().patch() == CMAKE_PROJECT_VERSION_PATCH, "patch version isn't the same");
     static_assert(floppy_meta.name() == std::string_view(stringify$(CMAKE_TARGET_NAME)), "project name isn't the same");
-    static_assert(floppy_meta.domain() == "io", "project domain isn't the same");
+    static_assert(floppy_meta.domain() == "io.github.whs31", "project domain isn't the same");
     static_assert(floppy_meta.organization() == "whs31", "project organization isn't the same");
   } // namespace meta
 } // namespace floppy

--- a/include/floppy/detail/formatters.h
+++ b/include/floppy/detail/formatters.h
@@ -32,3 +32,5 @@ namespace floppy
     }
   };
 } // namespace floppy
+
+// todo: formatters for version and meta

--- a/include/floppy/euclid/length.h
+++ b/include/floppy/euclid/length.h
@@ -1,0 +1,84 @@
+/// \file floppy/euclid/length.h
+/// \brief A one-dimensional distance with associated unit of measurement.
+/// \author whs31
+
+#pragma once
+
+#include <floppy/euclid/scale.h>
+
+namespace floppy::math
+{
+  /// \brief A one-dimensional distance with associated unit of measurement.
+  /// \details Unit is not used in the representation of a length value.
+  /// It is used only at compile time to ensure that a Length stored with one unit is converted
+  /// explicitly before being used in an expression that requires a different unit.
+  /// It may be a type without values, such as an empty struct.
+  /// You can multiply a length with a scale to convert it to another unit of measurement. See the \ref scale
+  /// docs for detailed example.
+  /// \tparam T Number type. Must satisfy concept <tt>floppy::concepts::num</tt>. Default is \c f32.
+  /// \tparam U Associated unit of measurement. Default is \ref default_unit.
+  /// \see floppy::math::scale
+  /// \see floppy::math::angle
+  template <typename U = default_unit, concepts::num T = f32>
+  class length : traits::formattable<length<U, T>, char>
+  {
+   public:
+    /// \brief Constructs an empty length.
+    constexpr length()
+      : m_(static_cast<T>(0.0F))
+    {}
+
+    /// \brief Constructs a length from a given numeric value.
+    explicit constexpr length(T value)
+      : m_(value)
+    {}
+
+    /// \brief Returns the underlying value.
+    [[nodiscard]] constexpr auto value() const -> T { return this->m_; }
+
+    /// \brief Casts the unit of measurement.
+    /// \tparam U2 New unit of measurement.
+    /// \return The length with the new unit of measurement and the same value.
+    template <typename U2>
+    [[nodiscard]] constexpr auto cast_unit() const -> length<U2, T> { return length<U2, T>(this->m_); }
+
+    /// \brief Cast from one numeric representation to another, preserving the units.
+    /// \tparam T2 New number type.
+    /// \return The length with the new number type and the same value.
+    template <concepts::num T2>
+    [[nodiscard]] constexpr auto cast() const -> length<U, T2> { return length<U, T2>(this->m_); }
+
+    /// \brief Linearly interpolate between this length and another length.
+    /// \details Example:
+    /// \code {.cpp}
+    /// auto const from = length(0.0F);
+    /// auto const to = length(8.0F);
+    /// fmt::println("{}", from.lerp(to, -1.0F));
+    /// fmt::println("{}", from.lerp(to, 0.0F));
+    /// fmt::println("{}", from.lerp(to, 0.5F));
+    /// fmt::println("{}", from.lerp(to, 1.0F));
+    /// fmt::println("{}", from.lerp(to, 2.0F));
+    /// \endcode
+    ///
+    /// Output:
+    /// \code {.sh}
+    /// -8.0
+    /// 0.0
+    /// 4.0
+    /// 8.0
+    /// 16.0
+    /// \endcode
+    /// \param other The other length.
+    /// \param t Interpolation factor.
+    /// \return The interpolated length.
+    [[nodiscard]] constexpr auto lerp(length<U, T> const& other, T t) const -> length<U, T> {
+      return length<U, T>(this->m_ + (other.m_ - this->m_) * t);
+    }
+
+    /// \brief Returns the underlying value.
+    [[nodiscard]] constexpr auto operator*() const -> T { return this->m_; }
+
+   private:
+    T m_;
+  };
+} // namespace floppy::math

--- a/include/floppy/euclid/length.h
+++ b/include/floppy/euclid/length.h
@@ -33,6 +33,21 @@ namespace floppy::math
       : m_(value)
     {}
 
+    constexpr length(length const&) = default;
+    constexpr length(length&&) = default;
+
+    /// \brief Returns string representation of the length.
+    /// \details Length is represented as it's numeric value. If the underlying number type is floating
+    /// point, it is rounded to three decimal places.
+    /// \note Due to limitations of the language, units are not displayed.
+    /// \return String representation of the object.
+    [[nodiscard]] virtual auto to_string() const -> std::string override {
+      if constexpr(std::is_floating_point_v<T>)
+        return fmt::format("{:.3f}", this->m_);
+      else
+        return fmt::format("{}", this->m_);
+    }
+
     /// \brief Returns the underlying value.
     [[nodiscard]] constexpr auto value() const -> T { return this->m_; }
 
@@ -77,6 +92,84 @@ namespace floppy::math
 
     /// \brief Returns the underlying value.
     [[nodiscard]] constexpr auto operator*() const -> T { return this->m_; }
+
+    constexpr auto operator=(T value) -> length& {
+      this->m_ = value;
+      return *this;
+    }
+
+    constexpr auto operator+=(length const& other) -> length& { return *this = *this + other; }
+    constexpr auto operator-=(length const& other) -> length& { return *this = *this - other; }
+    constexpr auto operator*=(length const& other) -> length& { return *this = *this * other; }
+    constexpr auto operator/=(length const& other) -> length& { return *this = *this / other; }
+
+    template <concepts::num T2>
+    constexpr auto operator+=(T2 value) -> length& { return *this = *this + static_cast<T>(value); }
+
+    template <concepts::num T2>
+    constexpr auto operator-=(T2 value) -> length& { return *this = *this - static_cast<T>(value); }
+
+    template <concepts::num T2>
+    constexpr auto operator*=(T2 value) -> length& { return *this = *this * static_cast<T>(value); }
+
+    template <concepts::num T2>
+    constexpr auto operator/=(T2 value) -> length& { return *this = *this / static_cast<T>(value); }
+
+    constexpr auto operator+(length const& other) const -> length { return length(this->m_ + other.m_); }
+    constexpr auto operator-(length const& other) const -> length { return length(this->m_ - other.m_); }
+    constexpr auto operator*(length const& other) const -> length { return length(this->m_ * other.m_); }
+
+    template <concepts::num T2>
+    constexpr auto operator+(T2 value) const -> length { return length(this->m_ + static_cast<T>(value)); }
+
+    template <concepts::num T2>
+    constexpr auto operator-(T2 value) const -> length { return length(this->m_ - static_cast<T>(value)); }
+
+    template <concepts::num T2>
+    constexpr auto operator*(T2 value) const -> length { return length(this->m_ * static_cast<T>(value)); }
+
+    template <concepts::num T2>
+    constexpr auto operator/(T2 value) const -> length { return length(this->m_ / static_cast<T>(value)); }
+
+    /// \brief Divides this length by length of another unit and return the result as a scale.
+    /// \tparam U2 Unit of the other length.
+    /// \tparam T2 Type of the other length.
+    /// \param other The other length.
+    /// \return The result as a scale ratio <i>U2/U</i> of type T of this length.
+    template <typename U2, concepts::num T2>
+    constexpr auto operator/(length<U2, T2> const& other) const -> scale<U2, U, T> {
+      return scale<U2, U, T>(this->value() / static_cast<T>(other.value()));
+    }
+
+    /// \brief Multiplies this length by scale factor.
+    /// \tparam U2 Unit of the scale factor.
+    /// \tparam T2 Type of the scale factor.
+    /// \param other The scale factor.
+    /// \return The result as a length of type T of this length.
+    template <typename U2, concepts::num T2>
+    constexpr auto operator*(scale<U, U2, T2> const& s) const -> length<U2, T> {
+      return length<U2, T>(this->value() * static_cast<T>(s.value()));
+    }
+
+    /// \brief Divides this length by scale factor.
+    /// \tparam U2 Unit of the scale factor.
+    /// \tparam T2 Type of the scale factor.
+    /// \param other The scale factor.
+    /// \return The result as a length of type T of this length.
+    template <typename U2, concepts::num T2>
+    constexpr auto operator/(scale<U2, U, T2> const& s) const -> length<U2, T> {
+      return length<U2, T>(this->value() / static_cast<T>(s.value()));
+    }
+
+    constexpr auto operator=(length const& other) -> length&  = default;
+    constexpr auto operator=(length&& other) -> length& = default;
+    constexpr auto operator-() const -> length { return length(-this->m_); }
+    [[nodiscard]] constexpr auto operator==(length const& other) const -> bool { return eq(this->m_, other.m_); }
+    [[nodiscard]] constexpr auto operator!=(length const& other) const -> bool { return not eq(this->m_, other.m_); }
+    [[nodiscard]] constexpr auto operator<(length const& other) const -> bool { return this->m_ < other.m_; }
+    [[nodiscard]] constexpr auto operator>(length const& other) const -> bool { return this->m_ > other.m_; }
+    [[nodiscard]] constexpr auto operator<=(length const& other) const -> bool { return this->m_ <= other.m_; }
+    [[nodiscard]] constexpr auto operator>=(length const& other) const -> bool { return this->m_ >= other.m_; }
 
    private:
     T m_;

--- a/include/floppy/euclid/scale.h
+++ b/include/floppy/euclid/scale.h
@@ -9,6 +9,9 @@
 
 namespace floppy::math
 {
+  /// \brief Default unit of measurement.
+  struct [[maybe_unused]] default_unit {};
+
   /// \brief A scaling factor between two different units of measurement.
   /// \headerfile floppy/euclid/scale.h
   /// \details This is effectively a type-safe float, intended to be used in combination with other types
@@ -40,7 +43,13 @@ namespace floppy::math
     /// \brief Underlying destination type.
     using destination_type = D;
 
-    /// \brief Creates a scale from a number.
+    /// \brief Constructs an identity scale.
+    /// \see scale::identity
+    constexpr scale()
+      : m_(1.0F)
+    {}
+
+    /// \brief Constructs a scale from a number.
     /// \param s Scale factor.
     /// \see scale::identity
     constexpr explicit scale(T s)

--- a/include/floppy/euclid/scale.h
+++ b/include/floppy/euclid/scale.h
@@ -115,7 +115,14 @@ namespace floppy::math
     /// \return This scale as number.
     [[nodiscard]] constexpr auto operator*() const -> T { return this->m_; }
 
-    [[nodiscard]] constexpr auto operator==(scale const& other) const -> bool { return eq(this->m_, other.m_); }
+    /// \brief Compares two scales.
+    /// \note If both scales are <tt>infinity</tt>, the result is <tt>true</tt>.
+    [[nodiscard]] constexpr auto operator==(scale const& other) const -> bool {
+      if(std::isinf(this->m_) and std::isinf(other.m_))
+        return true;
+      return eq(this->m_, other.m_);
+    }
+
     [[nodiscard]] constexpr auto operator!=(scale const& other) const -> bool { return not eq(this->m_, other.m_); }
     [[nodiscard]] constexpr auto operator<(scale const& other) const -> bool { return this->m_ < other.m_; }
     [[nodiscard]] constexpr auto operator>(scale const& other) const -> bool { return this->m_ > other.m_; }

--- a/tests/test_euclid_length.cc
+++ b/tests/test_euclid_length.cc
@@ -1,0 +1,181 @@
+#include <gtest/gtest.h>
+#include <floppy/floppy.h>
+#include <floppy/euclid/length.h>
+
+using fl::math::length;
+using fl::math::scale;
+using namespace fl::types;
+
+struct Inch {};
+struct Mm {};
+struct Cm {};
+struct Second {};
+
+TEST(EuclidLength, Clone)
+{
+  auto mut_len = length<Inch>(12.0F);
+  auto const len = mut_len;
+  mut_len = 24.0F;
+
+  EXPECT_FLOAT_EQ(*len, 12.0F);
+  EXPECT_FLOAT_EQ(*mut_len, 24.0F);
+}
+
+TEST(EuclidLength, Add)
+{
+  auto const a = length<Mm, u8>(250);
+  auto const b = length<Mm, u8>(5);
+
+  EXPECT_EQ(*(a + b), 255);
+  EXPECT_EQ(*(a + 5), 255);
+}
+
+TEST(EuclidLength, AddAssign)
+{
+  auto const one_cm = length<Mm>(10.0F);
+  auto measurement = length<Mm>(5.0F);
+  measurement += one_cm;
+
+  EXPECT_FLOAT_EQ(*measurement, 15.0F);
+}
+
+TEST(EuclidLength, Sub)
+{
+  auto const a = length<Mm, u8>(250);
+  auto const b = length<Mm, u8>(5);
+
+  EXPECT_EQ(*(a - b), 245);
+}
+
+TEST(EuclidLength, SubAssign)
+{
+  auto const one_cm = length<Mm>(10.0F);
+  auto measurement = length<Mm>(5.0F);
+  measurement -= one_cm;
+
+  EXPECT_FLOAT_EQ(*measurement, -5.0F);
+}
+
+TEST(EuclidLength, DivisionByLength)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const d = length<Second>(10.0F);
+  auto const result = l / d;
+  auto const expected = scale<Second, Cm>(0.5F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, Multiplication)
+{
+  auto const l_mm = length<Mm>(10.0F);
+  auto const cm_per_mm = scale<Mm, Cm>(0.1F);
+  auto const result = l_mm * cm_per_mm;
+  auto const expected = length<Cm>(1.0F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, MultiplicationWithScalar)
+{
+  auto const l_mm = length<Mm>(10.0F);
+  auto const result = l_mm * 2.0F;
+  auto const expected = length<Mm>(20.0F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, MultiplicationAssignment)
+{
+  auto mut_len = length<Mm>(10.0F);
+  mut_len *= 2.0F;
+  auto const expected = length<Mm>(20.0F);
+  EXPECT_EQ(mut_len, expected);
+}
+
+TEST(EuclidLength, DivisionByScaleFactor)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const s = scale<Second, Cm>(10.0F);
+  auto const result = l / s;
+  auto const expected = length<Second>(0.5F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, DivisionByScalar)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const result = l / 2.0F;
+  auto const expected = length<Cm>(2.5F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, DivisionAssignment)
+{
+  auto mut_len = length<Mm>(10.0F);
+  mut_len /= 2.0F;
+  auto const expected = length<Mm>(5.0F);
+  EXPECT_EQ(mut_len, expected);
+}
+
+TEST(EuclidLength, Format)
+{
+  auto const l = length<Cm>(5.0F);
+  EXPECT_EQ(fmt::format("{}", l), "5.000");
+}
+
+TEST(EuclidLength, Negation)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const result = -l;
+  auto const expected = length<Cm>(-5.0F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, Cast)
+{
+  auto const l = length<Cm, i32>(5);
+  auto const result = l.cast<f32>();
+  auto const expected = length<Cm>(5.0F);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, Equality)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const l2 = length<Cm>(5.1F);
+  auto const l3 = length<Cm>(0.1F);
+
+  EXPECT_TRUE(l == l2 - l3);
+  EXPECT_TRUE(l != l2);
+}
+
+TEST(EuclidLength, Ordering)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const l2 = length<Cm>(5.1F);
+  auto const l3 = length<Cm>(0.1F);
+
+  EXPECT_TRUE(l < l2);
+  EXPECT_TRUE(l <= l2);
+  EXPECT_TRUE(l <= l2 - l3);
+  EXPECT_TRUE(l2 > l);
+  EXPECT_TRUE(l2 >= l);
+  EXPECT_TRUE(l2 >= l - l3);
+}
+
+
+TEST(EuclidLength, ZeroAdd)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const l_zero = length<Cm>(0.0F);
+  auto const result = l + l_zero;
+  auto const expected = l - 0.0F;
+  EXPECT_EQ(result, expected);
+}
+
+TEST(EuclidLength, DivisionByZero)
+{
+  auto const l = length<Cm>(5.0F);
+  auto const l_zero = length<Cm>(0.0F);
+  auto const result = l / l_zero;
+  auto const expected = scale<Cm, Cm>(INFINITY);
+  EXPECT_EQ(result, expected);
+}


### PR DESCRIPTION
- Added `floppy::math::length` class - newtype wrapper for length values with associated unit of measurement, which is capable of multiplication and division by `scale`.