### PR TITLE
Added conversions from and to Qt types

### DIFF
--- a/include/floppy/detail/export.h
+++ b/include/floppy/detail/export.h
@@ -150,3 +150,15 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
 
 /// \brief Alias for the main namespace \ref floppy.
 namespace fl = floppy; // NOLINT(*-unused-alias-decls)
+
+#if defined(QT_CORE_LIB) || __has_include("qtglobal.h") || __has_include("qcoreapplication.h")
+# define FL_QT_CORE
+#endif
+
+#if defined(QT_GUI_LIB) || __has_include("qpainter.h") || __has_include("qguiapplication.h")
+# define FL_QT_GUI
+#endif
+
+#if defined(DOXYGEN_GENERATING_OUTPUT)
+# define FL_DOC
+#endif

--- a/include/floppy/euclid/point2d.h
+++ b/include/floppy/euclid/point2d.h
@@ -9,8 +9,9 @@
 #include <floppy/euclid/size2d.h>
 #include <floppy/euclid/detail/nt_traits2d.h>
 
-// todo: to qpoint
-// todo: to qpointf
+#if defined(FL_QT_GUI)
+# include <qpoint.h>
+#endif
 
 namespace floppy::math
 {
@@ -78,6 +79,19 @@ namespace floppy::math
 
     /// \brief Casts the point into size2d.
     [[nodiscard]] constexpr auto to_size2d() const -> size2d_type { return size2d_type(this->x(), this->y()); }
+
+    #if defined(FL_QT_GUI) || defined(FL_DOC)
+    /// \brief Casts this point2d into <tt>QPoint</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] constexpr auto to_qpoint() const -> QPoint {
+      auto const i = this->to_i32();
+      return QPoint(i.x(), i.y());
+    }
+
+    /// \brief Casts this point2d into <tt>QPointF</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] constexpr auto to_qpointf() const -> QPointF { return QPointF(this->x(), this->y()); }
+    #endif
 
     /// \brief Casts the unit of measurement.
     /// \tparam U2 New unit of measurement.

--- a/include/floppy/euclid/point2d.h
+++ b/include/floppy/euclid/point2d.h
@@ -265,5 +265,27 @@ namespace floppy::math
     /// \brief Constructs new point from size2d.
     /// \param other The other size2d.
     [[nodiscard]] static constexpr auto from_size2d(size2d_type const& other) -> point2d { return point2d(other); }
+
+    #if defined(FL_QT_GUI) || defined(FL_DOC)
+    /// \brief Constructs new point from <tt>QPoint</tt>.
+    /// \param other The other <tt>QPoint</tt>.
+    /// \remarks This constructor is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    constexpr explicit point2d(QPoint const& other) : point2d(other.x(), other.y()) {}
+
+    /// \brief Constructs new point from <tt>QPointF</tt>.
+    /// \param other The other <tt>QPointF</tt>.
+    /// \remarks This constructor is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    constexpr explicit point2d(QPointF const& other) : point2d(other.x(), other.y()) {}
+
+    /// \brief Constructs new point from <tt>QPoint</tt>.
+    /// \param other The other <tt>QPoint</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] static constexpr auto from_qpoint(QPoint const& other) -> point2d { return point2d(other.x(), other.y()); }
+
+    /// \brief Constructs new point from <tt>QPointF</tt>.
+    /// \param other The other <tt>QPointF</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] static constexpr auto from_qpointf(QPointF const& other) -> point2d { return point2d(other.x(), other.y()); }
+    #endif
   };
 } // namespace floppy::math

--- a/include/floppy/euclid/size2d.h
+++ b/include/floppy/euclid/size2d.h
@@ -218,5 +218,28 @@ namespace floppy::math
     [[nodiscard]] constexpr auto operator/(scale<U2, unit> const& s) const -> size2d<U2, underlying_type> {
       return size2d<U2, underlying_type>(this->x() / s.value(), this->y() / s.value());
     }
+
+#if defined(FL_QT_GUI) || defined(FL_DOC)
+    // and constructors
+    /// \brief Constructs new size2d from <tt>QSize</tt>.
+    /// \param other The other <tt>QSize</tt>.
+    /// \remarks This constructor is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    constexpr explicit size2d(QSize const& other) : size2d(other.width(), other.height()) {}
+
+    /// \brief Constructs new size2d from <tt>QSizeF</tt>.
+    /// \param other The other <tt>QSizeF</tt>.
+    /// \remarks This constructor is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    constexpr explicit size2d(QSizeF const& other) : size2d(other.width(), other.height()) {}
+
+    /// \brief Constructs new size2d from <tt>QSize</tt>.
+    /// \param other The other <tt>QSize</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] static constexpr auto from_qsize(QSize const& other) -> size2d { return size2d(other.width(), other.height()); }
+
+    /// \brief Constructs new size2d from <tt>QSizeF</tt>.
+    /// \param other The other <tt>QSizeF</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] static constexpr auto from_qsizef(QSizeF const& other) -> size2d { return size2d(other.width(), other.height()); }
+#endif
   };
 } // namespace floppy::math

--- a/include/floppy/euclid/size2d.h
+++ b/include/floppy/euclid/size2d.h
@@ -9,8 +9,9 @@
 #include <floppy/euclid/length.h>
 #include <floppy/euclid/detail/nt_traits2d.h>
 
-// todo: to qsize
-// todo: to qsizef
+#if defined(FL_QT_GUI)
+# include <qsize.h>
+#endif
 
 namespace floppy::math
 {
@@ -81,6 +82,19 @@ namespace floppy::math
     [[nodiscard]] constexpr auto to_untyped() const -> size2d<default_unit, underlying_type> {
       return size2d<default_unit, underlying_type>(this->x(), this->y());
     }
+
+    #if defined(FL_QT_GUI) || defined(FL_DOC)
+    /// \brief Casts this size2d into <tt>QSize</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] constexpr auto to_qsize() const -> QSize {
+      auto const i = this->to_i32();
+      return QSize(i.x(), i.y());
+    }
+
+    /// \brief Casts this size2d into <tt>QSizeF</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] constexpr auto to_qsizef() const -> QSizeF { return QSizeF(this->x(), this->y()); }
+    #endif
 
     /// \brief Casts the unit of measurement.
     /// \tparam U2 New unit of measurement.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(GTest REQUIRED)
 find_package(tomlplusplus REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui QUIET)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui QUIET)
 
 file(GLOB TEST_SOURCES "*.cc")
 
@@ -12,10 +14,13 @@ set_target_properties(${PROJECT_NAME}-test PROPERTIES
 
 target_sources(${PROJECT_NAME}-test PRIVATE ${TEST_SOURCES})
 
-target_link_libraries(${PROJECT_NAME}-test PRIVATE
+target_link_libraries(${PROJECT_NAME}-test
+  PRIVATE
   GTest::Main
   ${PROJECT_NAME}
   tomlplusplus::tomlplusplus
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
 )
 
 if(WIN32)

--- a/tests/test_euclid_point2d.cc
+++ b/tests/test_euclid_point2d.cc
@@ -164,6 +164,20 @@ TEST(EuclidPoint2D, DivEuclid)
   EXPECT_EQ(p.div_euclid(-s), point2d(-1.0, -2.0));
 }
 
+TEST(EuclidPoint2D, ToQPoint)
+{
+  auto const p = point2d(1.0, 2.0);
+
+  EXPECT_EQ(p.to_qpoint(), QPoint(1, 2));
+}
+
+TEST(EuclidPoint2D, ToQPointF)
+{
+  auto const p = point2d(1.0, 2.0);
+
+  EXPECT_EQ(p.to_qpointf(), QPointF(1.0, 2.0));
+}
+
 /*
 #[test] pub fn test_add_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) + vec2(3.0, 4.0), Point2DMm::new(4.0, 6.0)); }
 #[test] pub fn test_add_assign_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) += vec2(3.0, 4.0), Point2DMm::new(4.0, 6.0)); }

--- a/tests/test_euclid_point2d.cc
+++ b/tests/test_euclid_point2d.cc
@@ -178,6 +178,13 @@ TEST(EuclidPoint2D, ToQPointF)
   EXPECT_EQ(p.to_qpointf(), QPointF(1.0, 2.0));
 }
 
+TEST(EuclidPoint2D, FromQPoint)
+{
+  auto const p = QPoint(1, 2);
+
+  EXPECT_EQ(point2d(p), point2d(1.0F, 2.0F));
+}
+
 /*
 #[test] pub fn test_add_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) + vec2(3.0, 4.0), Point2DMm::new(4.0, 6.0)); }
 #[test] pub fn test_add_assign_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) += vec2(3.0, 4.0), Point2DMm::new(4.0, 6.0)); }

--- a/tests/test_euclid_size2d.cc
+++ b/tests/test_euclid_size2d.cc
@@ -129,3 +129,17 @@ TEST(EuclidSize2D, NanEmpty)
   EXPECT_FALSE(b);
   EXPECT_FALSE(c);
 }
+
+TEST(EuclidSize2D, ToQSize)
+{
+  EXPECT_EQ(size2d(1.0, 2.0).to_qsize(), QSize(1, 2));
+  EXPECT_EQ(size2d(0.0, 0.0).to_qsize(), QSize(0, 0));
+  EXPECT_EQ(size2d(-1.0, -2.0).to_qsize(), QSize(-1, -2));
+}
+
+TEST(EuclidSize2D, ToQSizeF)
+{
+  EXPECT_EQ(size2d(1.0, 2.0).to_qsizef(), QSizeF(1.0, 2.0));
+  EXPECT_EQ(size2d(0.0, 0.0).to_qsizef(), QSizeF(0.0, 0.0));
+  EXPECT_EQ(size2d(-1.0, -2.0).to_qsizef(), QSizeF(-1.0, -2.0));
+}


### PR DESCRIPTION
- Added conversion from and to `QPointF` and `QPoint` for class `floppy::math::point2d<U, T>`
- Added conversion from and to `QSizeF` and `QSize` for class `floppy::math::size2d<U, T>`