### PR TITLE
`floppy::math::vector2d` class 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,13 +14,13 @@ Checks:
   google-explicit-constructor,
   llvm-namespace-comment,
   misc-*,
-  -misc-non-private-member-variables-in-classes,
   readability-*,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,
   -readability-braces-around-statements,
-  -misc-include-cleaner
   -cppcoreguidelines-explicit-virtual-functions
+  -misc-non-private-member-variables-in-classes,
+  -misc-include-cleaner
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,7 +2,7 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="ClangTidy" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES">
-      <option name="clangTidyChecks" value="-*,boost-*,cppcoreguidelines-*,modernize-*,performance-*,portability-*,bugprone-*,-bugprone-easily-swappable-parameters,google-readability-casting,google-runtime-int,google-explicit-constructor,llvm-namespace-comment,misc-*,-misc-include-cleaner,-misc-non-private-member-variables-in-classes,readability-*,-readability-identifier-length,-readability-implicit-bool-conversion,-readability-braces-around-statements,-cppcoreguidelines-explicit-virtual-functions" />
+      <option name="clangTidyChecks" value="-*,boost-*,modernize-*,performance-*,portability-*,bugprone-*,-bugprone-easily-swappable-parameters,cppcoreguidelines-*,-cppcoreguidelines-explicit-virtual-functions,google-readability-casting,google-runtime-int,google-explicit-constructor,llvm-namespace-comment,misc-*,-misc-include-cleaner,-misc-non-private-member-variables-in-classes,readability-*,-readability-identifier-length,-readability-magic-numbers,-readability-implicit-bool-conversion,-readability-braces-around-statements" />
     </inspection_tool>
     <inspection_tool class="Clazy" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="TEXT_STYLE_WARNING" />
     <inspection_tool class="OCUnusedConcept" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,13 @@ target_sources(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/serialization.h> $<INSTALL_INTERFACE:include/floppy/serialization.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/configuration.h> $<INSTALL_INTERFACE:include/floppy/configuration.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/logging.h> $<INSTALL_INTERFACE:include/floppy/logging.h>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid.h> $<INSTALL_INTERFACE:include/floppy/euclid..h>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid.h> $<INSTALL_INTERFACE:include/floppy/euclid.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/angle.h> $<INSTALL_INTERFACE:include/floppy/euclid/angle.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/scale.h> $<INSTALL_INTERFACE:include/floppy/euclid/scale.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/length.h> $<INSTALL_INTERFACE:include/floppy/euclid/length.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/point2d.h> $<INSTALL_INTERFACE:include/floppy/euclid/point2d.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/size2d.h> $<INSTALL_INTERFACE:include/floppy/euclid/size2d.h>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/vector2d.h> $<INSTALL_INTERFACE:include/floppy/euclid/vector2d.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/detail/nt_traits.h> $<INSTALL_INTERFACE:include/floppy/euclid/detail/nt_traits.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/euclid/detail/nt_traits2d.h> $<INSTALL_INTERFACE:include/floppy/euclid/detail/nt_traits2d.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/floppy/inl/configuration.inl> $<INSTALL_INTERFACE:include/floppy/inl/configuration.inl>

--- a/include/floppy/configuration.h
+++ b/include/floppy/configuration.h
@@ -159,7 +159,7 @@ namespace floppy
 
    protected:
     /// \brief Reads content of configuration file from file.
-    auto read_from_file() const noexcept(false) -> std::string;
+    [[nodiscard]] auto read_from_file() const noexcept(false) -> std::string;
 
     /// \brief Writes content of configuration file to a file.
     auto write_to_file(std::string_view content) const noexcept(false) -> void;

--- a/include/floppy/detail/export.h
+++ b/include/floppy/detail/export.h
@@ -24,6 +24,7 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
   /// \brief Metadata definitions, such as library version or name.
   namespace meta {
     namespace detail {
+      // todo: this must be rewritten
       constexpr auto is_digit(char c) -> bool { return c <= '9' && c >= '0'; }
       constexpr auto stoi_impl(char const* str, int value = 0) -> int {
         return *str ? is_digit(*str)

--- a/include/floppy/detail/math.h
+++ b/include/floppy/detail/math.h
@@ -46,7 +46,7 @@ namespace floppy::math
       [[nodiscard]]
       constexpr auto as_degrees() const -> T { return 180.0; } // NOLINT(*-magic-numbers)
     };
-  }
+  } // namespace numbers
 
   /// \brief Returns true if numbers are equal
   /// \details Compares floating point values using formula <tt>|a - b| <= epsilon</tt>

--- a/include/floppy/detail/math.h
+++ b/include/floppy/detail/math.h
@@ -54,7 +54,7 @@ namespace floppy::math
   /// \param b Second number
   /// \tparam T Number type
   /// \return True if numbers are equal
-  /// \see null
+  /// \see is_null, approx_eq, strong_compare
   template <typename T>
   [[nodiscard]] constexpr auto eq(T a, T b) -> bool {
     if constexpr(std::is_floating_point_v<T>)
@@ -63,11 +63,27 @@ namespace floppy::math
       return a == b;
   }
 
+  /// \brief Returns true if numbers are approximately equal
+  /// \details Compares floating point values using formula <tt>|a - b| <= epsilon * epsilon_factor</tt>
+  /// \param a First number
+  /// \param b Second number
+  /// \param epsilon_factor Epsilon factor for comparison
+  /// \tparam T Number type
+  /// \return True if numbers are approximately equal
+  /// \see is_null, eq, strong_compare
+  template <typename T>
+  [[nodiscard]] constexpr auto approx_eq(T a, T b, T epsilon_factor) -> bool {
+    if constexpr(std::is_floating_point_v<T>)
+      return std::abs(a - b) <= std::numeric_limits<T>::epsilon() * epsilon_factor;
+    else
+      return a == b;
+  }
+
   /// \brief Returns true if type is equal to zero (number specific)
   /// \param num Number
   /// \tparam T Number type
   /// \return True if number is equal to zero
-  /// \see eq
+  /// \see eq, approx_eq, strong_compare
   template <concepts::num T>
   [[nodiscard]] constexpr auto is_null(T num) -> bool { return eq(num, T(0.0)); }
 
@@ -76,7 +92,7 @@ namespace floppy::math
   /// \param b Second number
   /// \tparam T Number type
   /// \note Treats <tt>NaN</tt> as equal to <tt>NaN</tt> and <tt>inf</tt> as equal to <tt>inf</tt> in case of floating points.
-  /// \see eq
+  /// \see eq, approx_eq, is_null
   /// \return Comparison result
   template <concepts::num T>
   [[nodiscard]] constexpr auto strong_compare(T a, T b) -> std::strong_ordering {

--- a/include/floppy/detail/platform.h
+++ b/include/floppy/detail/platform.h
@@ -379,4 +379,4 @@ namespace floppy
 
   /// \brief Constant-initialized variable, containing current platform information.
   inline auto constexpr current_platform = platform::current();
-} // namespace floppy::platform
+} // namespace floppy

--- a/include/floppy/detail/print_helpers.h
+++ b/include/floppy/detail/print_helpers.h
@@ -32,7 +32,7 @@ namespace floppy::print_helpers
       fmt::format(fmt::runtime(format), std::forward<Args>(args)...)
     );
   }
-}
+} // namespace floppy::print_helpers
 
 /// \defgroup macros Macros
 

--- a/include/floppy/detail/types.h
+++ b/include/floppy/detail/types.h
@@ -54,7 +54,7 @@ namespace floppy // NOLINT(*-concat-nested-namespaces)
     /// \brief Shortcut for <tt>std::reference_wrapper</tt>.
     template <typename T>
     using ref = std::reference_wrapper<T>;
-  }
+  } // namespace types
 
   /// \brief Inline namespace for literal operators.
   inline namespace literals
@@ -114,5 +114,5 @@ namespace floppy // NOLINT(*-concat-nested-namespaces)
     inline auto operator""_pvoid(unsigned long long value) -> void* { return reinterpret_cast<void*>(value); }
 
     // NOLINTEND(*-pro-type-reinterpret-cast, *-no-int-to-ptr)
-  }
+  } // namespace literals
 } // namespace floppy

--- a/include/floppy/euclid.h
+++ b/include/floppy/euclid.h
@@ -9,5 +9,6 @@
 #include <floppy/euclid/scale.h>
 #include <floppy/euclid/size2d.h>
 #include <floppy/euclid/point2d.h>
+#include <floppy/euclid/vector2d.h>
 
 // todo: operators between point and size

--- a/include/floppy/euclid/angle.h
+++ b/include/floppy/euclid/angle.h
@@ -80,9 +80,6 @@ namespace floppy::math
       return *this + this->angle_to(other) * t;
     }
 
-    /// \brief Returns true if the angle is a finite number.
-    [[nodiscard]] constexpr auto is_finite() const -> bool { return ::std::isfinite(this->m_); }
-
     /// \brief Return \f$(sin(x), cos(x))\f$.
     [[nodiscard]] constexpr auto sin_cos() const -> std::pair<T, T> {
       return std::make_pair(std::sin(this->m_), std::cos(this->m_));

--- a/include/floppy/euclid/detail/nt_traits.h
+++ b/include/floppy/euclid/detail/nt_traits.h
@@ -16,6 +16,7 @@ namespace floppy::math::detail
       return (strong_compare(**static_cast<T const*>(this), *other) == std::strong_ordering::less
         or strong_compare(**static_cast<T const*>(this), *other) == std::strong_ordering::equal);
     }
+
     [[nodiscard]] constexpr auto operator>=(T const& other) const -> bool {
       return (strong_compare(**static_cast<T const*>(this), *other) == std::strong_ordering::greater
         or strong_compare(**static_cast<T const*>(this), *other) == std::strong_ordering::equal);

--- a/include/floppy/euclid/detail/nt_traits.h
+++ b/include/floppy/euclid/detail/nt_traits.h
@@ -75,6 +75,27 @@ namespace floppy::math::detail
     /// \brief Returns this numeric newtype as 64-bit floating point number.
     [[maybe_unused]] [[nodiscard]] constexpr auto as_f64() const -> underlying_type { return this->as<f64>(); }
 
+    /// \brief Returns true if this is a finite number.
+    [[nodiscard]] constexpr auto is_finite() const -> bool { return ::std::isfinite(this->m_); }
+
+    /// \brief Returns <b>sin</b>(this).
+    [[nodiscard]] constexpr auto sin() const -> T { return std::sin(this->m_); }
+
+    /// \brief Returns <b>cos</b>(this).
+    [[nodiscard]] constexpr auto cos() const -> T { return std::cos(this->m_); }
+
+    /// \brief Returns <b>tan</b>(this).
+    [[nodiscard]] constexpr auto tan() const -> T { return std::tan(this->m_); }
+
+    /// \brief Returns <b>asin</b>(this).
+    [[nodiscard]] constexpr auto asin() const -> T { return std::asin(this->m_); }
+
+    /// \brief Returns <b>acos</b>(this).
+    [[nodiscard]] constexpr auto acos() const -> T { return std::acos(this->m_); }
+
+    /// \brief Returns <b>atan</b>(this).
+    [[nodiscard]] constexpr auto atan() const -> T { return std::atan(this->m_); }
+
     [[nodiscard]] constexpr auto operator++() -> T& { ++this->m_; return *this; }
     [[nodiscard]] constexpr auto operator++(int) -> T { auto ret = *this; ++this->m_; return ret; }
     [[nodiscard]] constexpr auto operator--() -> T& { --this->m_; return *this; }

--- a/include/floppy/euclid/detail/nt_traits2d.h
+++ b/include/floppy/euclid/detail/nt_traits2d.h
@@ -46,6 +46,16 @@ namespace floppy::math::detail
       , y_(value)
     {}
 
+    /// \brief Returns inverted basic_two_dimensional_type.
+    /// \return Inverted basic_two_dimensional_type.
+    /// \see yx
+    [[nodiscard]] constexpr auto inverted() const -> T { return T(this->y_, this->x_); }
+
+    /// \brief Same as <i>inverted</i>.
+    /// \return Inverted basic_two_dimensional_type.
+    /// \see inverted
+    [[nodiscard]] constexpr auto yx() const -> T { return this->inverted(); }
+
     /// \brief Returns the x-coordinate of the basic_two_dimensional_type as scalar value.
     /// \return The x-coordinate of the basic_two_dimensional_type.
     [[nodiscard]] constexpr auto x() const -> underlying_type { return this->x_; }
@@ -167,6 +177,21 @@ namespace floppy::math::detail
     /// \brief Returns the absolute value of each component.
     /// \return The absolute value of each component.
     [[nodiscard]] constexpr auto abs() const -> T { return T(std::abs(this->x_), std::abs(this->y_)); }
+
+    /// \brief Returns dot product of this and another basic_two_dimensional_type.
+    /// \param other The other basic_two_dimensional_type.
+    /// \return The dot product of this and another basic_two_dimensional_type.
+    [[nodiscard]] constexpr auto dot(T const& other) const -> underlying_type {
+      return this->x_ * other.x_ + this->y_ * other.y_;
+    }
+
+    /// \brief Returns the norm of the cross product of this and another basic_two_dimensional_type.
+    /// \details Cross product is defined as <code>[x1, y1] x [x2, y2] = x1 * y2 - y1 * x2</code>.
+    /// \param other The other basic_two_dimensional_type.
+    /// \return The norm of the cross product of this and another basic_two_dimensional_type.
+    [[nodiscard]] constexpr auto cross(T const& other) const -> underlying_type {
+      return this->x_ * other.y_ - this->y_ * other.x_;
+    }
 
     /// \brief Returns true if all members are finite.
     [[nodiscard]] constexpr auto is_finite() const -> bool { return std::isfinite(this->x_) && std::isfinite(this->y_); }

--- a/include/floppy/euclid/length.h
+++ b/include/floppy/euclid/length.h
@@ -27,7 +27,7 @@ namespace floppy::math
   {
    public:
     /// \brief Associated unit of measurement.
-    using unit = U;
+    using unit_type = U;
 
     /// \brief Constructs an empty length.
     constexpr length()

--- a/include/floppy/euclid/point2d.h
+++ b/include/floppy/euclid/point2d.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <floppy/euclid/length.h>
 #include <floppy/euclid/size2d.h>
+#include <floppy/euclid/vector2d.h>
 #include <floppy/euclid/detail/nt_traits2d.h>
 
 #if defined(FL_QT_GUI)
@@ -60,7 +61,11 @@ namespace floppy::math
 
     /// \brief Constructs new point from size2d.
     /// \param other The other size2d.
-    [[nodiscard]] constexpr explicit point2d(size2d_type const& other) : point2d(other.x(), other.y()) {}
+    constexpr explicit point2d(size2d_type const& other) : point2d(other.x(), other.y()) {}
+
+    /// \brief Constructs new point from a vector2d.
+    /// \param v The vector2d to copy.
+    constexpr explicit point2d(vector2d<default_unit, underlying_type> const& v) : detail::basic_two_dimensional_type<point2d<U, T>, U, T>(v.x(), v.y()) {}
 
     /// \brief Applies the function <b>fn</b> to each component of the point.
     /// \tparam U2 The new point2d's numeric scalar type.
@@ -77,10 +82,19 @@ namespace floppy::math
       return point2d<default_unit, underlying_type>(this->x(), this->y());
     }
 
-    /// \brief Casts the point into size2d.
-    [[nodiscard]] constexpr auto to_size2d() const -> size2d_type { return size2d_type(this->x(), this->y()); }
+    /// \brief Converts this point2d into <tt>size2d</tt>.
+    /// \return The resulting size2d.
+    [[nodiscard]] constexpr auto to_size2d() const -> size2d_type {
+      return size2d_type(this->x(), this->y());
+    }
 
-    #if defined(FL_QT_GUI) || defined(FL_DOC)
+    /// \brief Converts this point2d into <tt>vector2d</tt>.
+    /// \return The resulting vector2d.
+    [[nodiscard]] constexpr auto to_vector2d() const -> vector2d<unit_type, underlying_type> {
+      return vector2d<unit_type, underlying_type>(this->x(), this->y());
+    }
+
+  #if defined(FL_QT_GUI) || defined(FL_DOC)
     /// \brief Casts this point2d into <tt>QPoint</tt>.
     /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
     [[nodiscard]] constexpr auto to_qpoint() const -> QPoint {
@@ -91,7 +105,7 @@ namespace floppy::math
     /// \brief Casts this point2d into <tt>QPointF</tt>.
     /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
     [[nodiscard]] constexpr auto to_qpointf() const -> QPointF { return QPointF(this->x(), this->y()); }
-    #endif
+  #endif
 
     /// \brief Casts the unit of measurement.
     /// \tparam U2 New unit of measurement.
@@ -186,8 +200,6 @@ namespace floppy::math
       );
     }
 
-    // todo: same two methods for size2d
-
     /// \brief Constructs new point with zero coordinates.
     [[nodiscard]] static constexpr auto origin() -> point2d { return point2d(); }
 
@@ -237,26 +249,26 @@ namespace floppy::math
     }
 
     template <concepts::any_of<point2d, size2d_type> Q>
-    [[nodiscard]] constexpr auto operator+=(Q const& other) -> point2d& {
+    constexpr auto operator+=(Q const& other) -> point2d& {
       this->x_mut() += other.x();
       this->y_mut() += other.y();
       return *this;
     }
 
     template <concepts::any_of<point2d, size2d_type> Q>
-    [[nodiscard]] constexpr auto operator-=(Q const& other) -> point2d& {
+    constexpr auto operator-=(Q const& other) -> point2d& {
       this->x_mut() -= other.x();
       this->y_mut() -= other.y();
       return *this;
     }
 
-    [[nodiscard]] constexpr auto operator*=(underlying_type const& other) -> point2d& {
+    constexpr auto operator*=(underlying_type const& other) -> point2d& {
       this->x_mut() *= other;
       this->y_mut() *= other;
       return *this;
     }
 
-    [[nodiscard]] constexpr auto operator/=(underlying_type const& other) -> point2d& {
+    constexpr auto operator/=(underlying_type const& other) -> point2d& {
       this->x_mut() /= other;
       this->y_mut() /= other;
       return *this;
@@ -266,7 +278,7 @@ namespace floppy::math
     /// \param other The other size2d.
     [[nodiscard]] static constexpr auto from_size2d(size2d_type const& other) -> point2d { return point2d(other); }
 
-    #if defined(FL_QT_GUI) || defined(FL_DOC)
+  #if defined(FL_QT_GUI) || defined(FL_DOC)
     /// \brief Constructs new point from <tt>QPoint</tt>.
     /// \param other The other <tt>QPoint</tt>.
     /// \remarks This constructor is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
@@ -286,6 +298,6 @@ namespace floppy::math
     /// \param other The other <tt>QPointF</tt>.
     /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
     [[nodiscard]] static constexpr auto from_qpointf(QPointF const& other) -> point2d { return point2d(other.x(), other.y()); }
-    #endif
+  #endif
   };
 } // namespace floppy::math

--- a/include/floppy/euclid/point2d.h
+++ b/include/floppy/euclid/point2d.h
@@ -27,13 +27,13 @@ namespace floppy::math
   {
    public:
     /// \brief Associated unit type.
-    using unit = U;
+    using unit_type = U;
 
     /// \brief Underlying number type.
     using underlying_type = T;
 
     /// \brief Associated size2d type.
-    using size2d_type = size2d<unit, underlying_type>;
+    using size2d_type = size2d<unit_type, underlying_type>;
 
     /// \brief Constructs new point with zero coordinates.
     constexpr point2d() : detail::basic_two_dimensional_type<point2d<U, T>, U, T>() {}
@@ -46,7 +46,7 @@ namespace floppy::math
     /// \brief Constructs new point from proper <i>length</i> values.
     /// \param x The x-coordinate in <i>unit</i>.
     /// \param y The y-coordinate in <i>unit</i>.
-    constexpr point2d(length<unit> x, length<unit> y) : detail::basic_two_dimensional_type<point2d<U, T>, U, T>(x, y) {}
+    constexpr point2d(length<unit_type> x, length<unit_type> y) : detail::basic_two_dimensional_type<point2d<U, T>, U, T>(x, y) {}
 
     /// \brief Constructs new point, setting all components to the same value.
     /// \param value The value to set all components to.
@@ -66,7 +66,7 @@ namespace floppy::math
     /// \tparam U2 The new point2d's numeric scalar type.
     /// \param fn The function to apply.
     template <concepts::num U2>
-    constexpr auto map(std::function<U2(U)> fn) const { return point2d<unit, U2>(fn(this->x()), fn(this->y())); }
+    constexpr auto map(std::function<U2(U)> fn) const { return point2d<unit_type, U2>(fn(this->x()), fn(this->y())); }
 
     // todo: zip https://docs.rs/euclid/latest/euclid/struct.Point2D.html#method.zip
     // todo: extend https://docs.rs/euclid/latest/euclid/struct.Point2D.html#method.extend
@@ -105,48 +105,48 @@ namespace floppy::math
     /// \tparam T2 New number type.
     /// \return The point2d with the new number type and the same value.
     template <concepts::num T2>
-    [[nodiscard]] constexpr auto cast() const -> point2d<unit, T2> {
-      return point2d<unit, T2>(this->x(), this->y());
+    [[nodiscard]] constexpr auto cast() const -> point2d<unit_type, T2> {
+      return point2d<unit_type, T2>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>f32</tt> point2d.
-    [[nodiscard]] constexpr auto to_f32() const -> point2d<unit, f32> {
-      return point2d<unit, f32>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_f32() const -> point2d<unit_type, f32> {
+      return point2d<unit_type, f32>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>f64</tt> point2d.
-    [[nodiscard]] constexpr auto to_f64() const -> point2d<unit, f64> {
-      return point2d<unit, f64>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_f64() const -> point2d<unit_type, f64> {
+      return point2d<unit_type, f64>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>u32</tt> point2d.
-    [[nodiscard]] constexpr auto to_u32() const -> point2d<unit, u32> {
-      return point2d<unit, u32>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_u32() const -> point2d<unit_type, u32> {
+      return point2d<unit_type, u32>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>u64</tt> point2d.
-    [[nodiscard]] constexpr auto to_u64() const -> point2d<unit, u64> {
-      return point2d<unit, u64>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_u64() const -> point2d<unit_type, u64> {
+      return point2d<unit_type, u64>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>usize</tt> point2d.
-    [[nodiscard]] constexpr auto to_usize() const -> point2d<unit, usize> {
-      return point2d<unit, usize>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_usize() const -> point2d<unit_type, usize> {
+      return point2d<unit_type, usize>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>i32</tt> point2d.
-    [[nodiscard]] constexpr auto to_i32() const -> point2d<unit, i32> {
-      return point2d<unit, i32>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_i32() const -> point2d<unit_type, i32> {
+      return point2d<unit_type, i32>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>i64</tt> point2d.
-    [[nodiscard]] constexpr auto to_i64() const -> point2d<unit, i64> {
-      return point2d<unit, i64>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_i64() const -> point2d<unit_type, i64> {
+      return point2d<unit_type, i64>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>isize</tt> point2d.
-    [[nodiscard]] constexpr auto to_isize() const -> point2d<unit, isize> {
-      return point2d<unit, isize>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_isize() const -> point2d<unit_type, isize> {
+      return point2d<unit_type, isize>(this->x(), this->y());
     }
 
     // todo: to_3d https://docs.rs/euclid/latest/euclid/struct.Point2D.html#method.to_3d
@@ -154,8 +154,8 @@ namespace floppy::math
     /// \brief Returns distance between this and another point.
     /// \param other The other point.
     /// \return The distance.
-    [[nodiscard]] constexpr auto distance_to(point2d<U, T> const& other) const -> length<unit> {
-      return length<unit>(std::hypot(this->x() - other.x(), this->y() - other.y()));
+    [[nodiscard]] constexpr auto distance_to(point2d<U, T> const& other) const -> length<unit_type> {
+      return length<unit_type>(std::hypot(this->x() - other.x(), this->y() - other.y()));
     }
 
     /// \brief Calculates Euclidean division, the matching method for rem_euclid.
@@ -217,7 +217,7 @@ namespace floppy::math
     }
 
     template <typename U2, concepts::num T2>
-    [[nodiscard]] constexpr auto operator*(scale<unit, U2, T2> const& other) const -> point2d<U2, underlying_type> {
+    [[nodiscard]] constexpr auto operator*(scale<unit_type, U2, T2> const& other) const -> point2d<U2, underlying_type> {
       return point2d<U2, underlying_type>(
         this->x() * other.template as<underlying_type>(),
         this->y() * other.template as<underlying_type>()
@@ -229,7 +229,7 @@ namespace floppy::math
     }
 
     template <typename U2, concepts::num T2>
-    [[nodiscard]] constexpr auto operator/(scale<U2, unit, T2> const& other) const -> point2d<U2, underlying_type> {
+    [[nodiscard]] constexpr auto operator/(scale<U2, unit_type, T2> const& other) const -> point2d<U2, underlying_type> {
       return point2d<U2, underlying_type>(
         this->x() / other.template as<underlying_type>(),
         this->y() / other.template as<underlying_type>()

--- a/include/floppy/euclid/size2d.h
+++ b/include/floppy/euclid/size2d.h
@@ -18,6 +18,9 @@ namespace floppy::math
   template <typename U, concepts::num T>
   class point2d;
 
+  template <typename U, concepts::num T>
+  class vector2d;
+
   /// \brief A two-dimensional size2d tagged with a unit.
   /// \headerfile floppy/euclid.h
   /// \tparam U Associated unit of measurement. Default is \ref default_unit.
@@ -57,6 +60,14 @@ namespace floppy::math
     /// \param value The value to set all components to.
     constexpr explicit size2d(underlying_type value) : detail::basic_two_dimensional_type<size2d<U, T>, U, T>(value) {}
 
+    /// \brief Constructs new size2d from a point2d.
+    /// \param p The point2d to copy.
+    constexpr explicit size2d(point2d<default_unit, underlying_type> const& p) : detail::basic_two_dimensional_type<size2d<U, T>, U, T>(p.x(), p.y()) {}
+
+    /// \brief Constructs new size2d from a vector2d.
+    /// \param v The vector2d to copy.
+    constexpr explicit size2d(vector2d<default_unit, underlying_type> const& v) : detail::basic_two_dimensional_type<size2d<U, T>, U, T>(v.x(), v.y()) {}
+
     /// \brief Tags a unitless value with units.
     /// \param p Unitless size2d
     template <typename U2 = default_unit>
@@ -90,6 +101,12 @@ namespace floppy::math
     /// \return The resulting point2d.
     [[nodiscard]] constexpr auto to_point2d() const -> point2d<unit_type, underlying_type> {
       return point2d<unit_type, underlying_type>(this->x(), this->y());
+    }
+
+    /// \brief Converts this size2d into <tt>vector2d</tt>.
+    /// \return The resulting vector2d.
+    [[nodiscard]] constexpr auto to_vector2d() const -> vector2d<unit_type, underlying_type> {
+      return vector2d<unit_type, underlying_type>(this->x(), this->y());
     }
 
     #if defined(FL_QT_GUI) || defined(FL_DOC)
@@ -194,25 +211,25 @@ namespace floppy::math
       return size2d(this->x() / other, this->y() / other);
     }
 
-    [[nodiscard]] constexpr auto operator+=(const size2d& other) -> size2d& {
+    constexpr auto operator+=(const size2d& other) -> size2d& {
       this->x_mut() += other.x();
       this->y_mut() += other.y();
       return *this;
     }
 
-    [[nodiscard]] constexpr auto operator-=(const size2d& other) -> size2d& {
+    constexpr auto operator-=(const size2d& other) -> size2d& {
       this->x_mut() -= other.x();
       this->y_mut() -= other.y();
       return *this;
     }
 
-    [[nodiscard]] constexpr auto operator*=(const underlying_type& other) -> size2d& {
+    constexpr auto operator*=(const underlying_type& other) -> size2d& {
       this->x_mut() *= other;
       this->y_mut() *= other;
       return *this;
     }
 
-    [[nodiscard]] constexpr auto operator/=(const underlying_type& other) -> size2d& {
+    constexpr auto operator/=(const underlying_type& other) -> size2d& {
       this->x_mut() /= other;
       this->y_mut() /= other;
       return *this;

--- a/include/floppy/euclid/size2d.h
+++ b/include/floppy/euclid/size2d.h
@@ -30,7 +30,7 @@ namespace floppy::math
   {
    public:
     /// \brief Associated unit type.
-    using unit = U;
+    using unit_type = U;
 
     /// \brief Underlying number type.
     using underlying_type = T;
@@ -51,7 +51,7 @@ namespace floppy::math
     /// \brief Constructs new size2d from proper <i>length</i> values.
     /// \param x The x-coordinate in <i>unit</i>.
     /// \param y The y-coordinate in <i>unit</i>.
-    constexpr size2d(length<unit> x, length<unit> y) : detail::basic_two_dimensional_type<size2d<U, T>, U, T>(x, y) {}
+    constexpr size2d(length<unit_type> x, length<unit_type> y) : detail::basic_two_dimensional_type<size2d<U, T>, U, T>(x, y) {}
 
     /// \brief Constructs new size2d, setting all components to the same value.
     /// \param value The value to set all components to.
@@ -76,10 +76,10 @@ namespace floppy::math
     [[nodiscard]] constexpr auto height_mut() -> underlying_type& { return this->y_mut(); }
 
     /// \brief Alias to <tt>lx</tt> member function.
-    [[nodiscard]] constexpr auto width_typed() const -> length<unit> { return this->lx(); }
+    [[nodiscard]] constexpr auto width_typed() const -> length<unit_type> { return this->lx(); }
 
     /// \brief Alias to <tt>ly</tt> member function.
-    [[nodiscard]] constexpr auto height_typed() const -> length<unit> { return this->ly(); }
+    [[nodiscard]] constexpr auto height_typed() const -> length<unit_type> { return this->ly(); }
 
     /// \brief Drops the units from the size2d, returning just the numeric scalar values.
     [[nodiscard]] constexpr auto to_untyped() const -> size2d<default_unit, underlying_type> {
@@ -88,8 +88,8 @@ namespace floppy::math
 
     /// \brief Converts this size2d into <tt>point2d</tt>.
     /// \return The resulting point2d.
-    [[nodiscard]] constexpr auto to_point2d() const -> point2d<unit, underlying_type> {
-      return point2d<unit, underlying_type>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_point2d() const -> point2d<unit_type, underlying_type> {
+      return point2d<unit_type, underlying_type>(this->x(), this->y());
     }
 
     #if defined(FL_QT_GUI) || defined(FL_DOC)
@@ -117,48 +117,48 @@ namespace floppy::math
     /// \tparam T2 New number type.
     /// \return The size2d with the new number type and the same value.
     template <concepts::num T2>
-    [[nodiscard]] constexpr auto cast() const -> size2d<unit, T2> {
-      return size2d<unit, T2>(this->x(), this->y());
+    [[nodiscard]] constexpr auto cast() const -> size2d<unit_type, T2> {
+      return size2d<unit_type, T2>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>f32</tt> size2d.
-    [[nodiscard]] constexpr auto to_f32() const -> size2d<unit, f32> {
-      return size2d<unit, f32>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_f32() const -> size2d<unit_type, f32> {
+      return size2d<unit_type, f32>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>f64</tt> size2d.
-    [[nodiscard]] constexpr auto to_f64() const -> size2d<unit, f64> {
-      return size2d<unit, f64>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_f64() const -> size2d<unit_type, f64> {
+      return size2d<unit_type, f64>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>u32</tt> size2d.
-    [[nodiscard]] constexpr auto to_u32() const -> size2d<unit, u32> {
-      return size2d<unit, u32>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_u32() const -> size2d<unit_type, u32> {
+      return size2d<unit_type, u32>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>u64</tt> size2d.
-    [[nodiscard]] constexpr auto to_u64() const -> size2d<unit, u64> {
-      return size2d<unit, u64>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_u64() const -> size2d<unit_type, u64> {
+      return size2d<unit_type, u64>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>usize</tt> size2d.
-    [[nodiscard]] constexpr auto to_usize() const -> size2d<unit, usize> {
-      return size2d<unit, usize>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_usize() const -> size2d<unit_type, usize> {
+      return size2d<unit_type, usize>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>i32</tt> size2d.
-    [[nodiscard]] constexpr auto to_i32() const -> size2d<unit, i32> {
-      return size2d<unit, i32>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_i32() const -> size2d<unit_type, i32> {
+      return size2d<unit_type, i32>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>i64</tt> size2d.
-    [[nodiscard]] constexpr auto to_i64() const -> size2d<unit, i64> {
-      return size2d<unit, i64>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_i64() const -> size2d<unit_type, i64> {
+      return size2d<unit_type, i64>(this->x(), this->y());
     }
 
     /// \brief Casts into <tt>isize</tt> size2d.
-    [[nodiscard]] constexpr auto to_isize() const -> size2d<unit, isize> {
-      return size2d<unit, isize>(this->x(), this->y());
+    [[nodiscard]] constexpr auto to_isize() const -> size2d<unit_type, isize> {
+      return size2d<unit_type, isize>(this->x(), this->y());
     }
 
     /// \brief Returns result of multiplication of both scalars.
@@ -219,12 +219,12 @@ namespace floppy::math
     }
 
     template <typename U2>
-    [[nodiscard]] constexpr auto operator*(scale<unit, U2> const& s) const -> size2d<U2, underlying_type> {
+    [[nodiscard]] constexpr auto operator*(scale<unit_type, U2> const& s) const -> size2d<U2, underlying_type> {
       return size2d<U2, underlying_type>(this->x() * s.value(), this->y() * s.value());
     }
 
     template <typename U2>
-    [[nodiscard]] constexpr auto operator/(scale<U2, unit> const& s) const -> size2d<U2, underlying_type> {
+    [[nodiscard]] constexpr auto operator/(scale<U2, unit_type> const& s) const -> size2d<U2, underlying_type> {
       return size2d<U2, underlying_type>(this->x() / s.value(), this->y() / s.value());
     }
 

--- a/include/floppy/euclid/size2d.h
+++ b/include/floppy/euclid/size2d.h
@@ -39,9 +39,9 @@ namespace floppy::math
     using underlying_type = T;
 
     constexpr size2d(size2d const&) = default;
-    constexpr size2d& operator=(size2d const&) = default;
+    constexpr auto operator=(size2d const&) -> size2d& = default;
     constexpr size2d(size2d&&) = default;
-    constexpr size2d& operator=(size2d&&) = default;
+    constexpr auto operator=(size2d&&) -> size2d& = default;
 
     /// \brief Constructs new size2d with zero coordinates.
     constexpr size2d() : detail::basic_two_dimensional_type<size2d<U, T>, U, T>() {}
@@ -181,8 +181,6 @@ namespace floppy::math
     /// \brief Returns result of multiplication of both scalars.
     /// \return Area of the size2d.
     [[nodiscard]] constexpr auto area() const -> underlying_type { return this->x() * this->y(); }
-
-    // todo: to_vector()
 
     [[nodiscard]] constexpr auto operator+() const -> size2d { return *this; }
     [[nodiscard]] constexpr auto operator-() const -> size2d { return size2d(-this->x(), -this->y()); }

--- a/include/floppy/euclid/vector2d.h
+++ b/include/floppy/euclid/vector2d.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <functional>
+#include <floppy/euclid/angle.h>
 #include <floppy/euclid/length.h>
 #include <floppy/euclid/size2d.h>
 #include <floppy/euclid/detail/nt_traits2d.h>
@@ -13,8 +14,13 @@
 # include <qvector2d.h>
 #endif
 
+// todo: constructors from all 3 types inbetween
+
 namespace floppy::math
 {
+  template <typename U, concepts::num T>
+  class point2d;
+
   /// \brief A two-dimensional vector tagged with a unit.
   /// \headerfile floppy/euclid.h
   /// \tparam U Associated unit of measurement. Default is \ref default_unit.
@@ -27,6 +33,306 @@ namespace floppy::math
   {
    public:
     /// \brief Associated unit type.
-    using unit = U;
+    using unit_type = U;
+
+    /// \brief Underlying number type.
+    using underlying_type = T;
+
+    /// \brief Associated size2d type.
+    using size2d_type = size2d<unit_type, underlying_type>;
+
+    /// \brief Associated angle type.
+    using angle_type = angle<underlying_type>;
+
+    /// \brief Associated length type.
+    using length_type = length<unit_type, underlying_type>;
+
+    /// \brief Constructs new vector with zero coordinates.
+    constexpr vector2d() : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>() {}
+
+    /// \brief Constructs new vector from given scalar values.
+    /// \param x The x-coordinate.
+    /// \param y The y-coordinate.
+    constexpr vector2d(underlying_type x, underlying_type y) : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>(x, y) {}
+
+    /// \brief Constructs new vector from proper <i>length</i> values.
+    /// \param x The x-coordinate in <i>unit</i>.
+    /// \param y The y-coordinate in <i>unit</i>.
+    constexpr vector2d(length_type x, length_type y) : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>(x, y) {}
+
+    /// \brief Constructs new vector, setting all components to the same value.
+    /// \param value The value to set all components to.
+    constexpr explicit vector2d(underlying_type value) : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>(value) {}
+
+    /// \brief Tags a unitless value with units.
+    /// \param p Unitless vector2d
+    template <typename U2 = default_unit>
+      requires (not std::is_same_v<U, U2>)
+    constexpr explicit vector2d(vector2d<default_unit, T> const& p) : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>(p.x(), p.y()){}
+
+    /// \brief Constructs new vector from size2d.
+    /// \param other The other size2d.
+    [[nodiscard]] constexpr explicit vector2d(size2d_type const& other) : vector2d(other.x(), other.y()) {}
+
+    /// \brief Constructs new vector from point2d.
+    /// \param other The other point2d.
+    [[nodiscard]] constexpr explicit vector2d(point2d<U, T> const& other)
+      : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>(other.x(), other.y())
+    {}
+
+    /// \brief Constructs new vector from angle and length.
+    /// \param angle The angle in <i>unit</i>.
+    /// \param length The length in <i>unit</i>.
+    [[nodiscard]] constexpr explicit vector2d(angle_type angle, length_type length)
+      : detail::basic_two_dimensional_type<vector2d<U, T>, U, T>(length * angle.cos(), length * angle.sin())
+    {}
+
+    /// \brief Applies the function <b>fn</b> to each component of the vector2d.
+    /// \tparam U2 The new vector2d's numeric scalar type.
+    /// \param fn The function to apply.
+    template <concepts::num U2>
+    constexpr auto map(std::function<U2(U)> fn) const {
+      return vector2d<unit_type, U2>(fn(this->x()), fn(this->y()));
+    }
+
+    /// \brief Applies the function <b>fn</b> to each pair of components of this vector and <i>other</i> vector.
+    /// \tparam U2 The new vector2d's numeric scalar type.
+    /// \param other The other vector.
+    /// \param fn The function to apply.
+    template <concepts::num U2>
+    [[nodiscard]] constexpr auto zip(vector2d<unit_type, U2> const& other, std::function<U2(U, U2)> fn) const {
+      return vector2d<unit_type, U2>(fn(this->x(), other.x()), fn(this->y(), other.y()));
+    }
+
+    // todo: extend
+
+    /// \brief Casts this vector to a size2d.
+    /// \return The size2d representation of this vector.
+    [[nodiscard]] constexpr auto to_size2d() const { return size2d_type(this->x(), this->y()); }
+
+    /// \brief Casts this vector to a point2d.
+    /// \return The point2d representation of this vector.
+    [[nodiscard]] constexpr auto to_point2d() const { return point2d(this->x(), this->y()); }
+
+    /// \brief Drops the units from the vector, returning just the numeric scalar values.
+    [[nodiscard]] constexpr auto to_untyped() const -> vector2d<default_unit, underlying_type> {
+      return vector2d<default_unit, underlying_type>(this->x(), this->y());
+    }
+
+    // todo: to3d
+
+    /// \brief Returns this vector3d's length as scalar value.
+    /// \return The length of this vector3d.
+    [[nodiscard]] constexpr auto length() const -> underlying_type {
+      return underlying_type(std::sqrt(this->length_squared()));
+    }
+
+    /// \brief Returns this vector3d's length in associated <i>unit</i>.
+    /// \return The length of this vector3d in <i>unit</i>.
+    [[nodiscard]] constexpr auto length_typed() const -> length_type {
+      return length_type(std::sqrt(this->length_squared()));
+    }
+
+    /// \brief Returns this vector3d's length squared.
+    /// \return The length squared of this vector3d.
+    [[nodiscard]] constexpr auto length_squared() const -> underlying_type {
+      return this->x() * this->x() + this->y() * this->y();
+    }
+
+    /// \brief Returns this vector projected onto another vector.
+    /// \param other The other vector.
+    /// \return The projection of this vector onto the other vector.
+    /// \warning Projecting onto a zero vector will result in a division by zero.
+    [[nodiscard]] constexpr auto project(vector2d const& other) const -> vector2d {
+      return other * (this->dot(other) / other.length_squared());
+    }
+
+    /// \brief Returns the signed angle between this vector and another vector.
+    /// \param other The other vector.
+    /// \return The signed angle between this vector and the other vector.
+    [[nodiscard]] constexpr auto angle_to(vector2d const& other) const -> angle_type {
+      return angle_type::from_radians(std::atan2(this->cross(other), this->dot(other)));
+    }
+
+    /// \brief Returns the signed angle between this vector and the x axis.
+    /// \details Positive values counted counterclockwise, where 0 is <tt>+x</tt> axis, and <tt>PI/2</tt>
+    /// is <tt>+y</tt> axis.
+    /// \return The signed angle between this vector and the x axis.
+    [[nodiscard]] constexpr auto angle_to_x_axis() const -> angle_type {
+      return angle_type::from_radians(std::atan2(this->y(), this->x()));
+    }
+
+    /// \brief Returns the vector with length normalized.
+    /// \return The normalized vector.
+    [[nodiscard]] constexpr auto normalized() const -> vector2d { return *this / this->length(); }
+
+    /// \brief Returns this vector scaled to fit the provided length.
+    /// \param l The length to scale to.
+    /// \return The scaled vector.
+    [[nodiscard]] constexpr auto scaled_to(unit_type l) const -> vector2d { return this->normalized() * l; }
+
+    /// \brief Returns a reflection vector using an incident ray and a surface normal.
+    /// \param normal The surface normal.
+    /// \return The reflection vector.
+    [[nodiscard]] constexpr auto reflected(vector2d const& normal) const -> vector2d {
+      return *this - normal * underlying_type(2.0) * this->dot(normal);
+    }
+
+    /// \brief Casts the unit of measurement.
+    /// \tparam U2 New unit of measurement.
+    /// \return The vector2d with the new unit of measurement and the same value.
+    template <typename U2>
+    [[nodiscard]] constexpr auto cast_unit() const -> vector2d<U2, underlying_type> {
+      return vector2d<U2, underlying_type>(this->x(), this->y());
+    }
+
+    /// \brief Cast from one numeric representation to another, preserving the units.
+    /// \tparam T2 New number type.
+    /// \return The vector2d with the new number type and the same value.
+    template <concepts::num T2>
+    [[nodiscard]] constexpr auto cast() const -> vector2d<unit_type, T2> {
+      return vector2d<unit_type, T2>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>f32</tt> vector2d.
+    [[nodiscard]] constexpr auto to_f32() const -> vector2d<unit_type, f32> {
+      return vector2d<unit_type, f32>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>f64</tt> vector2d.
+    [[nodiscard]] constexpr auto to_f64() const -> vector2d<unit_type, f64> {
+      return vector2d<unit_type, f64>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>u32</tt> vector2d.
+    [[nodiscard]] constexpr auto to_u32() const -> vector2d<unit_type, u32> {
+      return vector2d<unit_type, u32>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>u64</tt> vector2d.
+    [[nodiscard]] constexpr auto to_u64() const -> vector2d<unit_type, u64> {
+      return vector2d<unit_type, u64>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>usize</tt> vector2d.
+    [[nodiscard]] constexpr auto to_usize() const -> vector2d<unit_type, usize> {
+      return vector2d<unit_type, usize>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>i32</tt> vector2d.
+    [[nodiscard]] constexpr auto to_i32() const -> vector2d<unit_type, i32> {
+      return vector2d<unit_type, i32>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>i64</tt> vector2d.
+    [[nodiscard]] constexpr auto to_i64() const -> vector2d<unit_type, i64> {
+      return vector2d<unit_type, i64>(this->x(), this->y());
+    }
+
+    /// \brief Casts into <tt>isize</tt> vector2d.
+    [[nodiscard]] constexpr auto to_isize() const -> vector2d<unit_type, isize> {
+      return vector2d<unit_type, isize>(this->x(), this->y());
+    }
+
+  #if defined(FL_QT_GUI) || defined(FL_DOC)
+    /// \brief Casts this vector2d into <tt>QVector2D</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] constexpr auto to_qvector2d() const -> QVector2D { return QVector2D(this->x(), this->y()); }
+  #endif
+
+    /// \brief Constructs new vector with all values set to one.
+    [[nodiscard]] static constexpr vector2d one() { return vector2d::splat(1.0); }
+
+    /// \brief Constructs new vector from angle and length.
+    /// \param angle The angle in <i>unit</i>.
+    /// \param length The length in <i>unit</i>.
+    [[nodiscard]] static constexpr vector2d from_angle_and_length(angle_type angle, length_type length) {
+      return vector2d(angle, length);
+    }
+
+    [[nodiscard]] constexpr auto operator+() const -> vector2d { return *this; }
+    [[nodiscard]] constexpr auto operator-() const -> vector2d { return vector2d(-this->x(), -this->y()); }
+
+    [[nodiscard]] constexpr auto operator==(vector2d const& other) const -> bool {
+      return approx_eq(this->x(), other.x(), static_cast<underlying_type>(3.0F))
+             and approx_eq(this->y(), other.y(), static_cast<underlying_type>(3.0F));
+    }
+
+    [[nodiscard]] constexpr auto operator!=(vector2d const& other) const -> bool {
+      return not approx_eq(this->x(), other.x(), static_cast<underlying_type>(3.0F))
+             or not approx_eq(this->y(), other.y(), static_cast<underlying_type>(3.0F));
+    }
+
+    template <concepts::any_of<vector2d, size2d_type> Q>
+    [[nodiscard]] constexpr auto operator+(Q const& other) const -> vector2d {
+      return vector2d(this->x() + other.x(), this->y() + other.y());
+    }
+
+    template <concepts::any_of<vector2d, size2d_type> Q>
+    [[nodiscard]] constexpr auto operator-(Q const& other) const -> vector2d {
+      return vector2d(this->x() - other.x(), this->y() - other.y());
+    }
+
+    [[nodiscard]] constexpr auto operator*(underlying_type const& other) const -> vector2d {
+      return vector2d(this->x() * other, this->y() * other);
+    }
+
+    template <typename U2, concepts::num T2>
+    [[nodiscard]] constexpr auto operator*(scale<unit_type, U2, T2> const& other) const -> vector2d<U2, underlying_type> {
+      return vector2d<U2, underlying_type>(
+        this->x() * other.template as<underlying_type>(),
+        this->y() * other.template as<underlying_type>()
+      );
+    }
+
+    [[nodiscard]] constexpr auto operator/(underlying_type const& other) const -> vector2d {
+      return vector2d(this->x() / other, this->y() / other);
+    }
+
+    template <typename U2, concepts::num T2>
+    [[nodiscard]] constexpr auto operator/(scale<U2, unit_type, T2> const& other) const -> vector2d<U2, underlying_type> {
+      return vector2d<U2, underlying_type>(
+        this->x() / other.template as<underlying_type>(),
+        this->y() / other.template as<underlying_type>()
+      );
+    }
+
+    template <concepts::any_of<vector2d, size2d_type> Q>
+    constexpr auto operator+=(Q const& other) -> vector2d& {
+      this->x_mut() += other.x();
+      this->y_mut() += other.y();
+      return *this;
+    }
+
+    template <concepts::any_of<vector2d, size2d_type> Q>
+    constexpr auto operator-=(Q const& other) -> vector2d& {
+      this->x_mut() -= other.x();
+      this->y_mut() -= other.y();
+      return *this;
+    }
+
+    constexpr auto operator*=(underlying_type const& other) -> vector2d& {
+      this->x_mut() *= other;
+      this->y_mut() *= other;
+      return *this;
+    }
+
+    constexpr auto operator/=(underlying_type const& other) -> vector2d& {
+      this->x_mut() /= other;
+      this->y_mut() /= other;
+      return *this;
+    }
+
+  #if defined(FL_QT_GUI) || defined(FL_DOC)
+    /// \brief Constructs new vector2d from <tt>QVector2D</tt>.
+    /// \param other The other <tt>QVector2D</tt>.
+    /// \remarks This constructor is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    constexpr explicit vector2d(QVector2D const& other) : vector2d(other.x(), other.y()) {}
+
+    /// \brief Constructs new vector2d from <tt>QVector2D</tt>.
+    /// \param other The other <tt>QVector2D</tt>.
+    /// \remarks This function is only available if <b>Qt Gui</b> is linked against the TU this header is compiled for.
+    [[nodiscard]] static constexpr auto from_qvector2d(QVector2D const& other) -> vector2d { return vector2d(other.x(), other.y()); }
+  #endif
   };
 } // namespace floppy::math

--- a/include/floppy/euclid/vector2d.h
+++ b/include/floppy/euclid/vector2d.h
@@ -1,0 +1,32 @@
+/// \file floppy/euclid/vector2d.h
+/// \brief A two-dimensional vector tagged with a unit.
+/// \author whs31
+
+#pragma once
+
+#include <functional>
+#include <floppy/euclid/length.h>
+#include <floppy/euclid/size2d.h>
+#include <floppy/euclid/detail/nt_traits2d.h>
+
+#if defined(FL_QT_GUI)
+# include <qvector2d.h>
+#endif
+
+namespace floppy::math
+{
+  /// \brief A two-dimensional vector tagged with a unit.
+  /// \headerfile floppy/euclid.h
+  /// \tparam U Associated unit of measurement. Default is \ref default_unit.
+  /// \tparam T Number type. Must satisfy concept <tt>floppy::concepts::num</tt>. Default is \c f32.
+  /// \see floppy::math::length
+  /// \see floppy::math::size2d
+  /// \see floppy::math::point2d
+  template <typename U = default_unit, concepts::num T = f32>
+  class vector2d : public detail::basic_two_dimensional_type<vector2d<U, T>, U, T>
+  {
+   public:
+    /// \brief Associated unit type.
+    using unit = U;
+  };
+} // namespace floppy::math

--- a/include/floppy/euclid/vector2d.h
+++ b/include/floppy/euclid/vector2d.h
@@ -14,8 +14,6 @@
 # include <qvector2d.h>
 #endif
 
-// todo: constructors from all 3 types inbetween
-
 namespace floppy::math
 {
   template <typename U, concepts::num T>
@@ -88,20 +86,20 @@ namespace floppy::math
     {}
 
     /// \brief Applies the function <b>fn</b> to each component of the vector2d.
-    /// \tparam U2 The new vector2d's numeric scalar type.
+    /// \tparam F The type of function to apply.
     /// \param fn The function to apply.
-    template <concepts::num U2>
-    constexpr auto map(std::function<U2(U)> fn) const {
-      return vector2d<unit_type, U2>(fn(this->x()), fn(this->y()));
+    template <std::invocable<underlying_type> F>
+    constexpr auto map(F&& fn) const {
+      return vector2d<unit_type, decltype(fn(this->x()))>(fn(this->x()), fn(this->y()));
     }
 
-    /// \brief Applies the function <b>fn</b> to each pair of components of this vector and <i>other</i> vector.
-    /// \tparam U2 The new vector2d's numeric scalar type.
-    /// \param other The other vector.
+    /// \brief Applies the function <b>fn</b> to each component of this vector2d and the other vector2d.
+    /// \tparam F The type of function to apply.
+    /// \param other The other vector2d to apply.
     /// \param fn The function to apply.
-    template <concepts::num U2>
-    [[nodiscard]] constexpr auto zip(vector2d<unit_type, U2> const& other, std::function<U2(U, U2)> fn) const {
-      return vector2d<unit_type, U2>(fn(this->x(), other.x()), fn(this->y(), other.y()));
+    template <std::invocable<underlying_type, underlying_type> F>
+    constexpr auto zip(vector2d const& other, F&& fn) const -> vector2d<unit_type, decltype(fn(this->x(), other.x()))> {
+      return vector2d<unit_type, decltype(fn(this->x(), other.x()))>(fn(this->x(), other.x()), fn(this->y(), other.y()));
     }
 
     // todo: extend
@@ -241,12 +239,12 @@ namespace floppy::math
   #endif
 
     /// \brief Constructs new vector with all values set to one.
-    [[nodiscard]] static constexpr vector2d one() { return vector2d::splat(1.0); }
+    [[nodiscard]] static constexpr auto one() -> vector2d { return vector2d::splat(1.0); }
 
     /// \brief Constructs new vector from angle and length.
     /// \param angle The angle in <i>unit</i>.
     /// \param length The length in <i>unit</i>.
-    [[nodiscard]] static constexpr vector2d from_angle_and_length(angle_type angle, length_type length) {
+    [[nodiscard]] static constexpr auto from_angle_and_length(angle_type angle, length_type length) -> vector2d {
       return vector2d(angle, length);
     }
 

--- a/include/floppy/logging.h
+++ b/include/floppy/logging.h
@@ -11,7 +11,7 @@ namespace floppy::log {
   /// \brief Logging levels.
   namespace level {
     using namespace spdlog::level;
-  } // namespace lvl
+  } // namespace level
 
   /// \brief Logs message to given loger with level <b>trace</b>.
   /// \tparam Args Format arguments.
@@ -161,4 +161,4 @@ namespace floppy::log {
   auto log(level::level_enum level, fmt::format_string<Args...> const& fmt, Args&&... args) -> void {
     log_to(level, *spdlog::default_logger(), fmt, std::forward<Args>(args)...);
   }
-} // namespace floppy::logging
+} // namespace floppy::log

--- a/include/floppy/serialization.h
+++ b/include/floppy/serialization.h
@@ -8,7 +8,7 @@
 namespace floppy::serialization
 {
   /// \brief Supported serialization formats.
-  enum class format
+  enum class format : u8
   {
     json,         ///< JSON format (JavaScript Object Notation)
     bson,         ///< JSON-like binary format

--- a/tests/test_euclid_point2d.cc
+++ b/tests/test_euclid_point2d.cc
@@ -6,6 +6,7 @@
 
 using fl::math::size2d;
 using fl::math::point2d;
+using fl::math::vector2d;
 using fl::math::default_unit;
 using fl::math::scale;
 using namespace fl::types;
@@ -185,9 +186,37 @@ TEST(EuclidPoint2D, FromQPoint)
   EXPECT_EQ(point2d(p), point2d(1.0F, 2.0F));
 }
 
-/*
-#[test] pub fn test_add_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) + vec2(3.0, 4.0), Point2DMm::new(4.0, 6.0)); }
-#[test] pub fn test_add_assign_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) += vec2(3.0, 4.0), Point2DMm::new(4.0, 6.0)); }
-#[test] pub fn test_sub_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) - vec2(3.0, 4.0), Point2DMm::new(-2.0, -2.0)); }
-#[test] pub fn test_sub_assign_vec() { assert_eq!(Point2DMm::new(1.0, 2.0) -= vec2(3.0, 4.0), Point2DMm::new(-2.0, -2.0)); }
-*/
+TEST(EuclidPoint2D, Map)
+{
+  auto const p = point2d(1.0, 2.0);
+  auto const expected = point2d<default_unit, i32>(2, 4);
+  auto fn = [](f64 x) -> i32 { return x * 2; };
+  EXPECT_EQ(p.map(fn), expected);
+}
+
+TEST(EuclidPoint2D, Zip)
+{
+  auto const p = point2d(1.0, 2.0);
+  auto const q = point2d(3.0, 4.0);
+  auto const got = p.zip(q, [](f64 x, f64 y) -> f64 { return x + y; });
+  auto const expected = point2d(4.0, 6.0);
+  EXPECT_EQ(got.to_size2d(), expected.to_size2d());
+}
+
+TEST(EuclidPoint2D, AddVec)
+{
+  auto const p = point2d(1.0, 2.0);
+  auto const v = vector2d(3.0, 4.0);
+  auto const got = p + v;
+  auto const expected = point2d(4.0, 6.0);
+  EXPECT_EQ(got, expected);
+}
+
+TEST(EuclidPoint2D, SubVec)
+{
+  auto const p = point2d(1.0, 2.0);
+  auto const v = vector2d(3.0, 4.0);
+  auto const got = p - v;
+  auto const expected = point2d(-2.0, -2.0);
+  EXPECT_EQ(got, expected);
+}

--- a/tests/test_euclid_vector2d.cc
+++ b/tests/test_euclid_vector2d.cc
@@ -190,3 +190,20 @@ TEST(EuclidVector2D, Reflect)
   EXPECT_EQ(a.reflected(n1), vector2d(1.0, -3.0));
   EXPECT_EQ(a.reflected(n2), vector2d(3.0, 1.0));
 }
+
+TEST(EuclidVector2D, Map)
+{
+  auto const p = vector2d(1.0, 2.0);
+  auto const expected = vector2d<default_unit, i32>(2, 4);
+  auto fn = [](f64 x) -> i32 { return x * 2; };
+  EXPECT_EQ(p.map(fn), expected);
+}
+
+TEST(EuclidVector2D, Zip)
+{
+  auto const p = vector2d(1.0, 2.0);
+  auto const q = vector2d(3.0, 4.0);
+  auto const got = p.zip(q, [](f64 x, f64 y) -> f64 { return x + y; });
+  auto const expected = vector2d(4.0, 6.0);
+  EXPECT_EQ(got.to_point2d(), expected.to_point2d());
+}

--- a/tests/test_euclid_vector2d.cc
+++ b/tests/test_euclid_vector2d.cc
@@ -1,0 +1,192 @@
+#include <vector>
+#include <numeric>
+#include <gtest/gtest.h>
+#include <floppy/floppy.h>
+#include <floppy/euclid.h>
+
+using fl::math::size2d;
+using fl::math::vector2d;
+using fl::math::point2d;
+using fl::math::default_unit;
+using fl::math::scale;
+using fl::math::angle;
+using namespace fl::types;
+
+struct Mm {};
+struct Cm {};
+
+TEST(EuclidVector2D, ScalarMul)
+{
+  auto const p1 = vector2d(3.0, 5.0);
+  auto const result = p1 * 5.0;
+
+  EXPECT_FLOAT_EQ(result.x(), 15.0);
+  EXPECT_FLOAT_EQ(result.y(), 25.0);
+  EXPECT_EQ(result, vector2d(15.0, 25.0));
+}
+
+TEST(EuclidVector2D, Dot)
+{
+  auto const p1 = vector2d(2.0, 7.0);
+  auto const p2 = vector2d(13.0, 11.0);
+  EXPECT_FLOAT_EQ(p1.dot(p2), 103.0);
+}
+
+TEST(EuclidVector2D, Cross)
+{
+  auto const p1 = vector2d(4.0, 7.0);
+  auto const p2 = vector2d(13.0, 8.0);
+  EXPECT_FLOAT_EQ(p1.cross(p2), -59.0);
+}
+
+TEST(EuclidVector2D, Normalize)
+{
+  auto const p1 = vector2d(4.0, 0.0);
+  auto const p2 = vector2d(3.0, -4.0);
+  EXPECT_FLOAT_EQ(p1.normalized().x(), 1.0);
+  EXPECT_FLOAT_EQ(p1.normalized().y(), 0.0);
+  EXPECT_FLOAT_EQ(p2.normalized().x(), 0.6);
+  EXPECT_FLOAT_EQ(p2.normalized().y(), -0.8);
+}
+
+TEST(EuclidVector2D, Length)
+{
+  auto const p1 = vector2d(3.0, 4.0);
+
+  EXPECT_FLOAT_EQ(p1.length(), 5.0);
+}
+
+TEST(EuclidVector2D, LengthSquared)
+{
+  auto const p1 = vector2d(3.0, 4.0);
+
+  EXPECT_FLOAT_EQ(p1.length_squared(), 25.0);
+}
+
+TEST(EuclidVector2D, Min)
+{
+  auto const p1 = vector2d(1.0, 3.0);
+  auto const p2 = vector2d(2.0, 2.0);
+
+  EXPECT_EQ(p1.min(p2), vector2d(1.0, 2.0));
+}
+
+TEST(EuclidVector2D, Max)
+{
+  auto const p1 = vector2d(1.0, 3.0);
+  auto const p2 = vector2d(2.0, 2.0);
+
+  EXPECT_EQ(p1.max(p2), vector2d(2.0, 3.0));
+}
+
+TEST(EuclidVector2D, AngleFromXAxis)
+{
+  auto const right = vector2d(10.0, 0.0);
+  auto const down = vector2d(0.0, 4.0);
+  auto const up = vector2d(0.0, -1.0);
+
+  EXPECT_EQ(right.angle_to_x_axis(), angle<f64>::zero());
+  EXPECT_EQ(down.angle_to_x_axis(), angle<f64>::half_pi());
+  EXPECT_EQ(up.angle_to_x_axis(), -angle<f64>::half_pi());
+}
+
+TEST(EuclidVector2D, AngleTo)
+{
+  auto const right = vector2d(10.0, 0.0);
+  auto const right2 = vector2d(1.0, 0.0);
+  auto const up = vector2d(0.0, -1.0);
+  auto const up_left = vector2d(-1.0, -1.0);
+
+  EXPECT_EQ(right.angle_to(right2), angle<f64>::zero());
+  EXPECT_EQ(right.angle_to(up), -angle<f64>::half_pi());
+  EXPECT_EQ(up.angle_to(right), angle<f64>::half_pi());
+  EXPECT_EQ(up_left.angle_to(up), angle<f64>::quarter_pi());
+}
+
+TEST(EuclidVector2D, ProjectOnto)
+{
+  auto const v1 = vector2d(1.0, 2.0);
+  auto const x = vector2d(1.0, 0.0);
+  auto const y = vector2d(0.0, 1.0);
+
+  EXPECT_EQ(v1.project(x), vector2d(1.0, 0.0));
+  EXPECT_EQ(v1.project(y), vector2d(0.0, 2.0));
+  EXPECT_EQ(v1.project(-x), vector2d(1.0, 0.0));
+  EXPECT_EQ(v1.project(x * 10.0), vector2d(1.0, 0.0));
+  EXPECT_EQ(v1.project(v1 * 2.0), v1);
+  EXPECT_EQ(v1.project(-v1), v1);
+}
+
+TEST(EuclidVector2D, Add)
+{
+  auto const p1 = vector2d(1.0, 2.0);
+  auto const p2 = vector2d(3.0, 4.0);
+
+  EXPECT_EQ(p1 + p2, vector2d(4.0, 6.0));
+  EXPECT_EQ(p1 + p2, vector2d(4.0, 6.0));
+}
+
+TEST(EuclidVector2D, Sum)
+{
+  auto vec = std::vector<vector2d<default_unit, f32>>{vector2d(1.0F, 2.0F), vector2d(3.0F, 4.0F), vector2d(5.0F, 6.0F)};
+  auto acc = std::accumulate(vec.begin(), vec.end(), vector2d());
+
+  EXPECT_EQ(acc, vector2d(9.0F, 12.0F));
+}
+
+TEST(EuclidVector2D, Sub)
+{
+  auto const p1 = vector2d(1.0, 2.0);
+  auto const p2 = vector2d(3.0, 4.0);
+
+  EXPECT_EQ(p1 - p2, vector2d(-2.0, -2.0));
+}
+
+TEST(EuclidVector2D, SubAssign)
+{
+  auto p1 = vector2d(1.0, 2.0);
+  p1 -= vector2d(3.0, 4.0);
+
+  EXPECT_EQ(p1, vector2d(-2.0, -2.0));
+}
+
+TEST(EuclidVector2D, MulAssign)
+{
+  auto p1 = vector2d(1.0, 2.0);
+  p1 *= 3.0;
+
+  EXPECT_EQ(p1, vector2d(3.0, 6.0));
+}
+
+TEST(EuclidVector2D, DivAssign)
+{
+  auto p1 = vector2d(3.0, 6.0);
+  p1 /= 3.0;
+
+  EXPECT_EQ(p1, vector2d(1.0, 2.0));
+}
+
+TEST(EuclidVector2D, Neg)
+{
+  auto p1 = vector2d(1.0, 2.0);
+  auto p2 = -p1;
+
+  EXPECT_EQ(p2, vector2d(-1.0, -2.0));
+}
+
+TEST(EuclidVector2D, Swizzle)
+{
+  auto p1 = vector2d(1.0, 2.0);
+
+  EXPECT_EQ(p1.yx(), vector2d(2.0, 1.0));
+}
+
+TEST(EuclidVector2D, Reflect)
+{
+  auto const a = vector2d(1.0, 3.0);
+  auto const n1 = vector2d(0.0, -1.0);
+  auto const n2 = vector2d(1.0, -1.0).normalized();
+
+  EXPECT_EQ(a.reflected(n1), vector2d(1.0, -3.0));
+  EXPECT_EQ(a.reflected(n2), vector2d(3.0, 1.0));
+}


### PR DESCRIPTION
- Added `floppy::math::vector2d` class 
- Fixed `map` and `zip` functions for `point2d`
- Fixed docs
- Added arithmetical ops between `point2d` and `vector2d`
- Added constructors for all three 2d types from each other
- Added conversions for all three 2d types into each other