### PR TITLE
GSL support extension

### DIFF
--- a/include/floppy/detail/export.h
+++ b/include/floppy/detail/export.h
@@ -10,14 +10,14 @@
 #   define FLOPPY_EXPORT __declspec(dllexport)
 # elif defined(FLOPPY_STATIC_LIBRARY)
 #   define FLOPPY_EXPORT
-# else
+# else // defined(FLOPPY_LIBRARY)
 #   define FLOPPY_EXPORT __declspec(dllimport)
-# endif
-#else
+# endif // defined(FLOPPY_LIBRARY)
+#else // defined(_WIN32)
 # define FLOPPY_EXPORT
-#endif
+#endif // defined(_WIN32)
 
-#define _stringify$(x) #x // NOLINT(*-macro-usage)
+#define _stringify$(x) #x // NOLINT(*-macro-usage, *-identifier-naming)
 #define stringify$(x) _stringify$(x) // NOLINT(*-macro-usage)
 
 /// \brief Main namespace for the library.
@@ -34,7 +34,7 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
       constexpr auto stoi_impl(char const* str, int value = 0) -> int {
         return *str ? is_digit(*str)
           ? stoi_impl(str + 1, (*str - '0') + value * 10)
-          : throw "compile-time-error: not a digit" : value;
+          : throw "compile time error: not a digit" : value;
       }
 
       /// \internal
@@ -154,14 +154,15 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
         FLOPPY_PROJECT_VERSION_MINOR,
         FLOPPY_PROJECT_VERSION_PATCH
       ),
-#else
+#else // defined(FLOPPY_PROJECT_VERSION_MAJOR)
       version(0, 0, 0),
-#endif
+#endif // defined(FLOPPY_PROJECT_VERSION_MAJOR)
+
 #if defined(FLOPPY_TARGET_NAME)
       std::string_view(stringify$(FLOPPY_TARGET_NAME)),
-#else
+#else // defined(FLOPPY_TARGET_NAME)
       std::string_view("floppy"),
-#endif
+#endif // defined(FLOPPY_TARGET_NAME)
       "io.github.whs31",
       "whs31"
     );
@@ -194,7 +195,7 @@ namespace floppy { // NOLINT(*-concat-nested-namespaces)
     static_assert(floppy_meta.name() == std::string_view(stringify$(FLOPPY_TARGET_NAME)), "project name isn't the same");
     static_assert(floppy_meta.domain() == "io.github.whs31", "project domain isn't the same");
     static_assert(floppy_meta.organization() == "whs31", "project organization isn't the same");
-#endif
+#endif // defined(FLOPPY_TARGET_NAME)
   } // namespace meta
 } // namespace floppy
 
@@ -211,16 +212,32 @@ namespace fl = floppy; // NOLINT(*-unused-alias-decls)
 /// \ingroup macros
 /// \brief Flag defined if <b>Qt::Core</b> library is available and linked.
 # define FL_QT_CORE
-#endif
+#endif // defined(QT_CORE_LIB)
 
 #if defined(QT_GUI_LIB) || __has_include("qpainter.h") || __has_include("qguiapplication.h") || defined(DOXYGEN_GENERATING_OUTPUT)
 /// \ingroup macros
 /// \brief Flag defined if <b>Qt::Gui</b> library is available and linked.
 # define FL_QT_GUI
-#endif
+#endif // defined(QT_GUI_LIB)
 
 #if defined(DOXYGEN_GENERATING_OUTPUT)
 /// \ingroup macros
 /// \brief Flag defined if documentation is being generated.
 # define FL_DOC
-#endif
+#endif // defined(DOXYGEN_GENERATING_OUTPUT)
+
+#if defined(NDEBUG) || defined(QT_NO_DEBUG)
+# define FL_NO_DEBUG
+#else // defined(NDEBUG) || defined(QT_NO_DEBUG)
+# define FL_DEBUG
+#endif // defined(NDEBUG)  || defined(QT_NO_DEBUG)
+
+/// \def FL_NO_DEBUG
+/// \brief Flag defined if debug mode is disabled.
+/// \details This macro disables some runtime checks, which are enabled in debug mode.
+/// Be sure to test your code in debug mode to avoid unexpected behavior.
+/// \ingroup macros
+
+/// \def FL_DEBUG
+/// \brief Flag defined if debug mode is enabled.
+/// \ingroup macros

--- a/include/floppy/detail/memory.h
+++ b/include/floppy/detail/memory.h
@@ -59,72 +59,96 @@ namespace floppy
     /// \brief Returns a mutable pointer to the underlying object.
     /// \returns A mutable pointer to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto get() -> T* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::get: use after consume");
+      #endif // FL_DEBUG
       return this->ptr_.get();
     }
 
     /// \brief Returns a mutable pointer to the underlying object.
     /// \returns A mutable pointer to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto get() const -> T* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::get: use after consume");
+      #endif // FL_DEBUG
       return this->ptr_.get();
     }
 
     /// \brief Returns a mutable pointer to the underlying object.
     /// \returns A mutable pointer to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto ptr_mut() -> T* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::ptr_mut: use after consume");
+      #endif // FL_DEBUG
       return this->ptr_.get();
     }
 
     /// \brief Returns an immutable pointer to the underlying object.
     /// \returns An immutable pointer to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto ptr() const -> T const* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::ptr: use after consume");
+      #endif // FL_DEBUG
       return this->ptr_.get();
     }
 
     /// \brief Returns a mutable reference to the underlying object.
     /// \returns A mutable reference to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto ref_mut() -> T& {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::ref_mut: use after consume");
+      #endif // FL_DEBUG
       return *this->ptr_;
     }
 
     /// \brief Returns an immutable reference to the underlying object.
     /// \returns An immutable reference to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto ref() const -> T const& {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::ref: use after consume");
+      #endif // FL_DEBUG
       return *this->ptr_;
     }
 
     /// \brief Returns a mutable reference to the underlying object.
     /// \returns A mutable reference to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto operator*() -> T& {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::operator*: use after consume");
+      #endif // FL_DEBUG
       return *this->ptr_;
     }
 
     /// \brief Returns an immutable reference to the underlying object.
     /// \returns An immutable reference to the underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto operator*() const -> T const& {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
-        throw invalid_smart_pointer_access("box::operator->: use after consume");
+        throw invalid_smart_pointer_access("box::operator*: use after consume");
+      #endif // FL_DEBUG
       return *this->ptr_;
     }
 
@@ -149,18 +173,24 @@ namespace floppy
     /// \brief Returns the underlying object.
     /// \returns The underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto operator->() -> T* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::operator->: use after consume");
+      #endif // FL_DEBUG
       return this->ptr_.get();
     }
 
     /// \brief Returns the underlying object.
     /// \returns The underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     [[nodiscard]] auto operator->() const -> T* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::operator->: use after consume");
+      #endif // FL_DEBUG
       return this->ptr_.get();
     }
 
@@ -184,10 +214,13 @@ namespace floppy
     /// \tparam U Type to downcast to.
     /// \returns An mutable reference to the casted underlying object if successful, <tt>none</tt> otherwise.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     template <typename U>
     [[nodiscard]] auto downcast() -> option<fl::types::ref<U>> {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::downcast: use after consume");
+      #endif // FL_DEBUG
       try {
         auto& r = dynamic_cast<U&>(this->ref_mut());
         return option<fl::types::ref<U>>{r};
@@ -202,10 +235,13 @@ namespace floppy
     /// \tparam U Type to cast to.
     /// \returns An mutable pointer to the casted underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     template <typename U>
     [[nodiscard]] auto as() -> U* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::as: use after consume");
+      #endif // FL_DEBUG
       return static_cast<U*>(this->ptr_mut());
     }
 
@@ -213,10 +249,13 @@ namespace floppy
     /// \tparam U Type to cast to.
     /// \returns An constant pointer to the casted underlying object.
     /// \throws invalid_smart_pointer_access If the box has been moved from or is leaked/consumed.
+    /// \warning This function is non-throwing in release mode. Exception is only thrown in debug mode.
     template <typename U>
     [[nodiscard]] auto as() const -> U const* {
+      #ifdef FL_DEBUG
       if(not this->ptr_)
         throw invalid_smart_pointer_access("box::as: use after consume");
+      #endif // FL_DEBUG
       return static_cast<U*>(this->ptr());
     }
 

--- a/include/floppy/detail/memory.h
+++ b/include/floppy/detail/memory.h
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <floppy/detail/export.h>
 #include <floppy/detail/formatters.h>
+#include <floppy/detail/concepts.h>
 
 namespace floppy
 {
@@ -17,6 +18,19 @@ namespace floppy
     using std::logic_error::logic_error;
     using std::logic_error::what;
   };
+
+  /// \brief GSL-like owning raw pointer typedef.
+  /// \headerfile floppy/floppy.h
+  /// \ingroup memory
+  /// \details <code>fl::owner<T></code> is designed as a safety mechanism for code that must deal
+  /// directly with raw pointers that own memory.
+  /// Ideally such code should be restricted to the implementation of low-level abstractions.
+  /// <code>fl::owner<T></code> can also be used
+  /// as a stepping point in converting legacy code to use more modern RAII constructs, such as smart pointers.
+  /// \tparam T Pointer type.
+  /// \sa https://github.com/microsoft/GSL/blob/main/include/gsl/pointers
+  template <concepts::ptr T>
+  using owner = T;
 
   /// \brief Box memory class.
   /// \headerfile floppy/floppy.h

--- a/include/floppy/graphics/color.h
+++ b/include/floppy/graphics/color.h
@@ -120,7 +120,7 @@ namespace floppy::gfx
   class color : public traits::formattable<color, char>
   {
     template <concepts::num T = u8>
-    static constexpr auto mask = static_cast<T>(std::numeric_limits<u8>::max());
+    static constexpr floppy::concepts::num auto mask = static_cast<T>(std::numeric_limits<u8>::max());
 
    public:
     /// \brief HSL color representation.
@@ -523,8 +523,7 @@ namespace floppy::gfx
     /// the next 8 bits are used as green component, the next 8 bits are used as blue component, and
     /// the last 8 bits are used as alpha component.
     /// \param rgba 32-bit unsigned integer.
-    constexpr explicit color(u32 rgba)
-    {
+    constexpr explicit color(u32 rgba) {
       if(rgba > 0xFFFFFF) {
         this->r_ = static_cast<f32>((rgba >> 24) & mask<u8>) / mask<f32>;
         this->g_ = static_cast<f32>((rgba >> 16) & mask<u8>) / mask<f32>;
@@ -548,8 +547,7 @@ namespace floppy::gfx
     /// </ul>
     /// \throws std::invalid_argument if the string is not a valid color.
     /// \param s String view.
-    constexpr explicit color(std::string_view s)
-    {
+    constexpr explicit color(std::string_view s) {
       if(s.starts_with("#"))
         s = s.substr(1);
       if (s.size() == 6) {
@@ -573,8 +571,7 @@ namespace floppy::gfx
     /// \param hsl HSL color value.
     /// \see from_hsl
     constexpr explicit color(color::hsl_t const& hsl)
-      : a_(1.0F)
-    {
+      : a_(1.0F) {
       auto const t = hsl.to_rgb();
       this->r_ = static_cast<f32>(t[0]) / mask<f32>;
       this->g_ = static_cast<f32>(t[1]) / mask<f32>;
@@ -584,8 +581,7 @@ namespace floppy::gfx
     /// \brief Constructs a color from HSLA values.
     /// \param hsla HSLA color value.
     /// \see from_hsla
-    explicit constexpr color(color::hsla_t const& hsla)
-    {
+    explicit constexpr color(color::hsla_t const& hsla) {
       auto const t = hsla.to_rgba();
       this->r_ = static_cast<f32>(t[0]) / mask<f32>;
       this->g_ = static_cast<f32>(t[1]) / mask<f32>;
@@ -597,8 +593,7 @@ namespace floppy::gfx
     /// \param hsv HSV color value.
     /// \see from_hsv
     explicit constexpr color(color::hsv_t const& hsv)
-      : a_(1.0F)
-    {
+      : a_(1.0F) {
       auto const t = hsv.to_rgb();
       this->r_ = static_cast<f32>(t[0]) / mask<f32>;
       this->g_ = static_cast<f32>(t[1]) / mask<f32>;
@@ -608,8 +603,7 @@ namespace floppy::gfx
     /// \brief Constructs a color from HSVA values.
     /// \param hsva HSVA color value.
     /// \see from_hsva
-    constexpr explicit color(color::hsva_t const& hsva)
-    {
+    constexpr explicit color(color::hsva_t const& hsva) {
       auto const t = hsva.to_rgba();
       this->r_ = static_cast<f32>(t[0]) / mask<f32>;
       this->g_ = static_cast<f32>(t[1]) / mask<f32>;
@@ -621,8 +615,7 @@ namespace floppy::gfx
     /// \param cmyk CMYK color value.
     /// \see from_cmyk
     constexpr explicit color(color::cmyk_t const& cmyk)
-      : a_{1.0F}
-    {
+      : a_{1.0F} {
       auto const t = cmyk.to_rgb();
       this->r_ = static_cast<f32>(t[0]) / mask<f32>;
       this->g_ = static_cast<f32>(t[1]) / mask<f32>;
@@ -632,8 +625,7 @@ namespace floppy::gfx
     /// \brief Constructs a color from CMYKA values.
     /// \param cmyka CMYKA color value.
     /// \see from_cmyka
-    constexpr explicit color(color::cmyka_t const& cmyka)
-    {
+    constexpr explicit color(color::cmyka_t const& cmyka) {
       auto const t = cmyka.to_rgba();
       this->r_ = static_cast<f32>(t[0]) / mask<f32>;
       this->g_ = static_cast<f32>(t[1]) / mask<f32>;
@@ -869,23 +861,39 @@ namespace floppy::gfx
     [[nodiscard]] constexpr auto operator!=(color const& other) const -> bool { return not (*this == other); }
 
     [[nodiscard]] constexpr auto operator+(color const& other) const -> color {
-      return {this->red() + other.red(), this->green() + other.green(),
-        this->blue() + other.blue(), this->alpha() + other.alpha()};
+      return {
+        static_cast<u8>(this->red() + other.red()),
+        static_cast<u8>(this->green() + other.green()),
+        static_cast<u8>(this->blue() + other.blue()),
+        static_cast<u8>(this->alpha() + other.alpha())
+      };
     }
 
     [[nodiscard]] constexpr auto operator-(color const& other) const -> color {
-      return {this->red() - other.red(), this->green() - other.green(),
-      this->blue() - other.blue(), this->alpha() - other.alpha()};
+      return {
+        static_cast<u8>(this->red() - other.red()),
+        static_cast<u8>(this->green() - other.green()),
+        static_cast<u8>(this->blue() - other.blue()),
+        static_cast<u8>(this->alpha() - other.alpha())
+      };
     }
 
     [[nodiscard]] constexpr auto operator*(color const& other) const -> color {
-      return {this->red() * other.red(), this->green() * other.green(),
-      this->blue() * other.blue(), this->alpha() * other.alpha()};
+      return {
+        static_cast<u8>(this->red() * other.red()),
+        static_cast<u8>(this->green() * other.green()),
+        static_cast<u8>(this->blue() * other.blue()),
+        static_cast<u8>(this->alpha() * other.alpha())
+      };
     }
 
     [[nodiscard]] constexpr auto operator/(color const& other) const -> color {
-      return {this->red() / other.red(), this->green() / other.green(),
-      this->blue() / other.blue(), this->alpha() / other.alpha()};
+      return {
+        static_cast<u8>(this->red() / other.red()),
+        static_cast<u8>(this->green() / other.green()),
+        static_cast<u8>(this->blue() / other.blue()),
+        static_cast<u8>(this->alpha() / other.alpha())
+      };
     }
 
     /// wtf ???
@@ -1004,7 +1012,7 @@ namespace floppy::gfx
         static_cast<f32>(col.alphaF())
       );
     }
-  #endif
+  #endif // FL_QT_GUI || FL_DOC
 
    private:
     f32 r_;

--- a/include/floppy/traits.h
+++ b/include/floppy/traits.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <memory>
 #include <iostream>
 #include <experimental/propagate_const>
-#include <floppy/detail/export.h>
-#include <floppy/detail/formatters.h>
-#include <floppy/detail/memory.h>
+#include <floppy/floppy.h>
 
 /// \brief Namespace with traits for custom types and classes.
 namespace floppy::traits


### PR DESCRIPTION
- Added `fl::owner<T>` class simular to `gsl::owner<T>`
- Fixed bug with `<floppy/traits.h>` header
- Fixed narrowing casts and warnings in color class implementation