### PR TITLE
`result` and `bytearray` types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "doxygen/preset"]
+	path = doxygen/preset
+	url = https://github.com/maybe-unused/doxygen-preset.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # -- dependencies --
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
+find_package(tl-expected REQUIRED)
 
 add_library(${PROJECT_NAME})
 add_library(${PROJECT_NAMESPACE}${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -55,6 +56,7 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
     fmt::fmt
     spdlog::spdlog
+    tl::expected
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include> PRIVATE src/c++)

--- a/LICENSE
+++ b/LICENSE
@@ -24,11 +24,13 @@ SOFTWARE.
 This software depends on the following libraries:
     - fmt lib (MIT License)
     - spdlog lib (MIT License)
+    - tl-expected lib (MIT License)
     - gtest lib (BSD License)
 
 and users must comply to its licenses:
     - https://raw.githubusercontent.com/fmtlib/fmt/master/LICENSE
     - https://github.com/gabime/spdlog/blob/master/LICENSE
+    - https://github.com/TartanLlama/tl-expected/blob/master/LICENSE
     - https://github.com/google/googletest/blob/master/googletest/LICENSE
 
 -- END NOTE --

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,6 +36,7 @@ class FloppyRecipe(ConanFile):
     def requirements(self):
         self.requires("fmt/[^10.1.0]", transitive_headers=True, transitive_libs=True)
         self.requires("spdlog/1.13.0", transitive_headers=True, transitive_libs=True)
+        self.requires("tl-expected/20190710", transitive_headers=True, transitive_libs=True)
         if self.options.test:
             self.requires("gtest/1.14.0")
             self.requires("tomlplusplus/[^3.0.0]", transitive_headers=True, transitive_libs=True)
@@ -76,7 +77,7 @@ class FloppyRecipe(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "floppy")
         self.cpp_info.set_property("cmake_target_name", "floppy::floppy")
         self.cpp_info.libs = ["floppy"]
-        self.cpp_info.requires = ["fmt::fmt", "spdlog::spdlog"]
+        self.cpp_info.requires = ["fmt::fmt", "spdlog::spdlog", "tl-expected::tl-expected"]
         if self.options.test:
             print(colored("▶ testing enabled. following libraries will be added to deps: gtest, tomlplusplus", "green"))
             self.cpp_info.requires.append("gtest::gtest")

--- a/doxygen/header.html
+++ b/doxygen/header.html
@@ -16,7 +16,7 @@
 <!-- BEGIN twitter metadata -->
 <meta name="twitter:image:src" content="https://repository-images.githubusercontent.com/348492097/4f16df80-88fb-11eb-9d31-4015ff22c452" />
 <meta name="twitter:title" content="Documentation for the Floppy library" />
-<meta name="twitter:description" content=""https://whs31.github.io/floppy" />
+<meta name="twitter:description" content="https://whs31.github.io/floppy" />
 <!-- END twitter metadata -->
 
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->

--- a/include/floppy/bytearray.h
+++ b/include/floppy/bytearray.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+#include <span>
+
+namespace floppy
+{
+  /// \brief Alias for <tt>std::vector<std::byte></tt>.
+  /// \details Provides owning byte array.
+  /// \ingroup aliases
+  /// \headerfile floppy/bytearray.h
+  /// \see bytearray_view, bytearray_view_mut
+  using bytearray = std::vector<std::byte>;
+
+  /// \brief Alias for <tt>std::span<std::byte const></tt>.
+  /// \details Provides non-owning view over a byte array.
+  /// \ingroup aliases
+  /// \headerfile floppy/bytearray.h
+  /// \see bytearray, bytearray_view_mut
+  using bytearray_view = std::span<std::byte const>;
+
+  /// \brief Alias for <tt>std::span<std::byte></tt>.
+  /// \details Provides mutable non-owning view over a byte array.
+  /// \ingroup aliases
+  /// \headerfile floppy/bytearray.h
+  /// \see bytearray, bytearray_view
+  using bytearray_view_mut = std::span<std::byte>;
+} // namespace floppy


### PR DESCRIPTION
- Added `fl::result<T>` - alias over `tl::expected<T, E>`, which provides alternative over exceptions.
- Added `fl::bytearray`, `fl::bytearray_view` and `fl::bytearray_view_mut` aliases.
- Fixed broken workflows.
- Fixed broken submodules.
 